### PR TITLE
docs(phase-5a): documentation and test coverage gaps from phase 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ What you need:
     - [Local Setup](#local-setup)
     - [Network Setup](#network-setup)
     - [Setup UI](#setup-ui)
-    - [Settings Screen](#settings-screen)
+    - [End-to-End Tests](#end-to-end-tests)
   - [Tag and Release](#tag-and-release)
     - [Versioning](#versioning)
     - [Tag, Build and Push to Docker Hub](#tag-build-and-push-to-docker-hub)
@@ -80,42 +80,27 @@ add your GH_TOKEN to the .npmrc file ${GH_TOKEN}
 3. Install the dependencies:
 
 ```bash
-yarn install --frozen-lockfile
+npm install
 ```
 
 4. Create a new .env file and copy the contents of the `env_sample` file to the newly created .env
 
 ```text
 NODE_ENV=development
-NEXT_PUBLIC_URL="http://{server_ip_address}:3001"
-PORT="3001"
-NEXT_PUBLIC_TMS_SERVER_URL="http://{server_ip_address}:5000"
-NEXT_PUBLIC_TMS_KEY=""
-NEXT_PUBLIC_CMS_NATS_HOSTING="nats://nats:4222"
-NEXT_PUBLIC_NATS_USERNAME=""
-NEXT_PUBLIC_NATS_PASSWORD=""
-
-NEXT_PUBLIC_PG_HOST=localhost
-NEXT_PUBLIC_PG_PORT=5432
-NEXT_PUBLIC_PG_USER=postgres
-NEXT_PUBLIC_PG_PASSWORD=password
-NEXT_PUBLIC_PG_DATABASE=configuration
-
-NEXT_PUBLIC_WS_URL="http://{your_machines_ip_address}:3001"
-
-NEXT_PUBLIC_NATS_SUBSCRIPTIONS="['connection', '>', 'typology-999@1.0.0']"
-
-NEXT_PUBLIC_ADMIN_SERVICE_HOSTING="http://{server_ip_address}:5100"
-NEXT_PUBLIC_CONDITION_TYPES="['non-overridable-block', 'overridable-block', 'override']"
-NEXT_PUBLIC_EVENT_TYPES="['pacs.008.001.10', 'pacs.002.001.12', 'pain.001.001.11', 'pain.013.001.09']"
-NEXT_PUBLIC_CONDITION_REASONS="['Suspicion of Money Laundering', 'Violation of KYC/AML Requirements', 'Suspicion of Terrorist Financing', 'Tax Evasion Concerns', 'Regulatory Reporting Thresholds', 'Unusual Transaction Patterns', 'High-Risk Countries', 'Multiple Failed Login Attempts', 'Fraudulent Activity', 'Phishing or Account Takeover', 'Suspicious Beneficiaries', 'System Errors', 'Exceeding Limits', 'Legal Holds or Court Orders', 'Adverse media reports', 'Dormant or Inactive Accounts', 'Internal Bank Policies']"
-
+PORT=3001
+NATS_SERVER_URL=nats://user:password@{server_ip_address}:4222
+ADMIN_SERVICE_URL=http://{server_ip_address}:5100
+TMS_SERVER_URL=http://{server_ip_address}:5000
+NEXT_PUBLIC_URL=http://{server_ip_address}:3001
+NEXT_PUBLIC_WS_URL=http://{server_ip_address}:3001
+AUTHENTICATED=false
+TEST_MODE=false
 ```
 
 5. Run the development server:
 
 ```bash
-yarn dev
+npm run dev
 ```
 
 6. Open [http://localhost:3001](http://localhost:3001) with your browser to see the result.
@@ -134,26 +119,37 @@ yarn dev
 
 >  <img width="60%" height="full" src="./public/first_load.png" alt="main"><br/>
 
-2. Click the gear icon on the top right for Settings
+<a><div align="right">[Top](#table-of-contents)</div></a>
 
-> <img width="60%" height="full" src="./public/settings.png" alt="settings"><br/>
+### End-to-End Tests
 
-### Settings Screen
+The e2e tests use [Playwright](https://playwright.dev/) and run entirely without a live Tazama stack. The server starts automatically in `TEST_MODE`, intercepting transaction submissions and emitting deterministic fixtures over Socket.IO.
 
-- TMS API Host URL: `http://localhost:5000`
+1. Install Playwright browsers (one-time, after `npm install`):
 
-  > **Check what port number is being used by the TMS server on the docker instance **(Default Port: 5000)***
+```bash
+npx playwright install chromium
+```
 
-- CMS NATS Hosting: `http://localhost:14222` if run outside of docker-compose else `nats://nats:4222`
-  
-  > **Check what port number is being used by the NATS server on the docker instance **(Default Port: 4222)***
+2. Run headless (CI-style):
 
-- PostgreSQL Hosting: `localhost:5432`
-  > **Check what port number is being used by the PostgreSQL server on your instance (Default Port: 5432)***
+```bash
+npm run e2e:headless
+```
 
+To view the HTML report after a headless run:
 
-- Websocket IP Address: `http://localhost:3001`
-  > **If run locally use `http://localhost:3001` else if run on a network or hosted use `http://{your_ip_address}:3001` **(Default Port: 3001)***
+```bash
+npx playwright show-report
+```
+
+3. Run in UI mode (interactive, with step-by-step timeline and live browser):
+
+```bash
+npm run e2e:ui
+```
+
+No `.env` file is needed to run the tests - all required environment variables are injected by `playwright.config.ts`.
 
 <a><div align="right">[Top](#table-of-contents)</div></a>
 
@@ -303,7 +299,6 @@ flowchart TD
   ```text
   Custom Server - Contains WebSocket and NATS Connections
   Package Management - Package.json
-  Application Settings and configurations
   ```
 
 - App Folder:
@@ -311,7 +306,6 @@ flowchart TD
   ```text
   Application Layout
   Main Page
-  Settings Page
   Handles navigation
   ```
 

--- a/e2e/transaction-journey.spec.ts
+++ b/e2e/transaction-journey.spec.ts
@@ -7,11 +7,54 @@ test.describe("Transaction journey", () => {
     await seedLocalStorage(page)
 
     // Mock the network-map endpoint - no external admin service available in test
+    // Rules and typologies must match the ids emitted by emitTestFixtures() in server.js:
+    //   Rule-001@1.0.0 and Rule-002@1.0.0 (looked up by title = id.split("@")[0])
+    //   typology-001@1.0.0 (looked up by title = cfg.split("@")[0])
     await page.route("/api/network-map", async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify({ rules: [], typologies: [], data: [] }),
+        body: JSON.stringify({
+          rules: [
+            {
+              id: 1,
+              title: "Rule-001",
+              rule: "Rule-001",
+              ruleDescription: "",
+              color: "n",
+              result: null,
+              wght: 0,
+              linkedTypologies: [],
+              displayLinkedTypo: [],
+              ruleBands: [],
+            },
+            {
+              id: 2,
+              title: "Rule-002",
+              rule: "Rule-002",
+              ruleDescription: "",
+              color: "n",
+              result: null,
+              wght: 0,
+              linkedTypologies: [],
+              displayLinkedTypo: [],
+              ruleBands: [],
+            },
+          ],
+          typologies: [
+            {
+              id: 1,
+              title: "typology-001",
+              cfg: "typology-001@1.0.0",
+              color: "n",
+              result: null,
+              typoDescription: "",
+              workflow: { alertThreshold: 400, interdictionThreshold: 600 },
+              linkedRules: [],
+            },
+          ],
+          data: [],
+        }),
       })
     })
 
@@ -71,5 +114,20 @@ test.describe("Transaction journey", () => {
 
     // The Event Adjudicator heading should still be present after processing
     await expect(page.getByRole("heading", { name: /event adjudicator/i })).toBeVisible()
+
+    // The ALRT badge should appear (adjudicatorLights.status = "ALRT", color = "y")
+    await expect(page.getByText("ALRT")).toBeVisible({ timeout: 8000 })
+
+    // Rules: wght=1.0 > 0 for both rules → color="r" (red) via updateTadpLights()
+    // following::img[n] counts only imgs AFTER the "Rules" heading in DOM order
+    const rulesHeading = page.getByRole("heading", { name: /^rules$/i })
+    await expect(rulesHeading.locator("xpath=following::img[1]")).toHaveAttribute("src", /red-light/, { timeout: 8000 })
+    await expect(rulesHeading.locator("xpath=following::img[2]")).toHaveAttribute("src", /red-light/, { timeout: 8000 })
+
+    // Typologies: result=500 >= alertThreshold=400 and < interdictionThreshold=600 → color="y" (yellow)
+    const typologiesHeading = page.getByRole("heading", { name: /^typologies$/i })
+    await expect(typologiesHeading.locator("xpath=following::img[1]")).toHaveAttribute("src", /yellow-light/, {
+      timeout: 8000,
+    })
   })
 })

--- a/sample.env
+++ b/sample.env
@@ -9,7 +9,8 @@ TMS_SERVER_URL=http://{server_ip_address}:5000
 # Client-side config (safe - no credentials)
 NEXT_PUBLIC_URL=http://{server_ip_address}:3001
 NEXT_PUBLIC_WS_URL=http://{server_ip_address}:3001
-# TODO Phase 3: Debtor.tsx:39 still reads this directly from browser - remove once
-# proxied through /api/tms route (Phase 3 scope).
-NEXT_PUBLIC_TMS_SERVER_URL=http://{server_ip_address}:5000
+# Set to true to enable Keycloak OIDC authentication
+AUTHENTICATED=false
+# Set to true to run Playwright e2e tests without a live Tazama stack
+TEST_MODE=false
 


### PR DESCRIPTION
Closes #100

## Summary

Three documentation and test coverage gaps identified after Phase 5, addressed in separate commits.

### Item 1 - `sample.env`

- Removed stale `NEXT_PUBLIC_TMS_SERVER_URL` entry and its `# TODO Phase 3` comment (Phase 3 is complete; `Debtor.tsx` now calls `/api/transaction` BFF route)
- Added `AUTHENTICATED=false` (Keycloak OIDC toggle) and `TEST_MODE=false` (Playwright fixture mode toggle) with explanatory comments

### Item 2 - `README.md`

- Removed `Settings Screen` TOC entry
- Replaced the stale env variable block (old `NEXT_PUBLIC_*` vars) with the current `sample.env` format
- Removed the "Click the gear icon for Settings" setup step and the associated screenshot
- Removed the entire `### Settings Screen` section (TMS URL, NATS, PostgreSQL, Websocket fields - all configured via `.env` since Phase 1)
- Fixed stale `yarn` references in Local Setup to `npm install` and `npm run dev`
- Added `### End-to-End Tests` section with browser install step and headless/UI run commands
- Cleaned up the Folder Structure section (removed "Application Settings and configurations" and "Settings Page" entries)

### Item 3 - `e2e/transaction-journey.spec.ts`

- Updated the `beforeEach` `/api/network-map` mock to return rules (`Rule-001`, `Rule-002`) and a typology (`typology-001`) matching the IDs emitted by `emitTestFixtures()` in `server.js`
- Extended the "pipeline processes" test with assertions for:
  - ALRT badge visible (`adjudicatorLights.status = "ALRT"`, `color = "y"`)
  - Rule-001 and Rule-002 red (`wght = 1.0 > 0` via `updateTadpLights()`)
  - typology-001 yellow (`result 500 >= alertThreshold 400`, `result 500 < interdictionThreshold 600` via `updateTypologies()`)
