### PR TITLE
fix: copy env.mjs into production Docker stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,6 @@ COPY --from=builder /app/package-lock.json ./package-lock.json
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/server.js ./server.js
 COPY --from=builder /app/next.config.mjs ./next.config.mjs
+COPY --from=builder /app/env.mjs ./env.mjs
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary

The production Docker image was crashlooping on startup with:

```
Error: Cannot find module '/app/env.mjs' imported from /app/next.config.mjs
```

`next.config.mjs` imports `env.mjs` at module evaluation time. The production
stage copied `next.config.mjs` but omitted `env.mjs`, so the import failed
immediately when `node server.js` initialised the Next.js app.

## Change

Added a single `COPY` line to the production stage:

```dockerfile
COPY --from=builder /app/env.mjs ./env.mjs
```

## Verification

- Checked `server.js` for relative `require()` calls - none found (all deps are node_modules).
- Checked `.next/next-server.js.nft.json` and `.next/next-minimal-server.js.nft.json`
  (Node File Trace manifests) - the only non-.next, non-node_modules file listed is
  `package.json`, which is already present in the image.
- `env.mjs` itself only imports from node_modules (`@t3-oss/env-nextjs`, `zod`).

No other file omissions were found.
