### PR TITLE
fix: prevent AUTH_SERVICE_URL=\"\" Dockerfile default from failing startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,14 +25,15 @@ ENV PORT="3001"
 ENV NEXT_PUBLIC_URL="http://localhost:3001"
 ENV NEXT_PUBLIC_WS_URL="http://localhost:3001"
 
-# Server-side configuration (never exposed to browser)
-ENV NATS_SERVER_URL=""
-ENV ADMIN_SERVICE_URL=""
-ENV TMS_SERVER_URL=""
+# Server-side configuration (never exposed to browser).
+# Required vars (NATS_SERVER_URL, ADMIN_SERVICE_URL, TMS_SERVER_URL) must be
+# provided by the caller - no defaults are baked in so a missing value fails
+# fast at env.mjs validation rather than later at request time.
+# Optional vars (AUTH_SERVICE_URL, NEXTAUTH_SECRET) are intentionally left
+# unset so the caller can omit them; AUTHENTICATED defaults to "false" so the
+# image is usable out-of-the-box without an auth backend.
+# NEXTAUTH_SECRET is required when AUTHENTICATED=true - generate with: openssl rand -base64 32
 ENV AUTHENTICATED="false"
-ENV AUTH_SERVICE_URL=""
-# NEXTAUTH_SECRET is required in authenticated deployments - generate with: openssl rand -base64 32
-ENV NEXTAUTH_SECRET=""
 
 # Copy built artifacts from builder stage
 COPY --from=builder --chown=node:node /app/.next ./.next

--- a/env.mjs
+++ b/env.mjs
@@ -28,7 +28,10 @@ export const env = createEnv({
     ADMIN_SERVICE_URL: process.env.ADMIN_SERVICE_URL,
     TMS_SERVER_URL: process.env.TMS_SERVER_URL,
     AUTHENTICATED: process.env.AUTHENTICATED,
-    NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
-    AUTH_SERVICE_URL: process.env.AUTH_SERVICE_URL,
+    // Coerce empty strings to undefined so .optional() (which only accepts
+    // undefined, not "") works correctly when callers pass blank values via
+    // env_file or when Docker image defaults leave the var as "".
+    NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET || undefined,
+    AUTH_SERVICE_URL: process.env.AUTH_SERVICE_URL || undefined,
   },
 })


### PR DESCRIPTION
## Summary

Fixes #108: container startup fails with `Invalid environment variables: { AUTH_SERVICE_URL: [ 'Invalid url' ] }` when `AUTHENTICATED=false` and the caller does not supply `AUTH_SERVICE_URL`.

## Root cause

Two compounding problems, both in this repo:

1. `Dockerfile` baked in empty-string defaults for optional auth vars (`ENV AUTH_SERVICE_URL=""`, `ENV NEXTAUTH_SECRET=""`). Docker `ENV` cannot be un-set by an `env_file` - only overridden to another value - so `process.env.AUTH_SERVICE_URL` was guaranteed to be at least `""` at runtime.
2. `env.mjs` validates `AUTH_SERVICE_URL` as `z.string().url().optional()`. Zod's `.optional()` only excuses `undefined`, not `""`, so `.url()` ran on the empty string and rejected it.

The same shape of bug was latent on `NEXTAUTH_SECRET` (no `.url()`, so it never tripped - but the empty-string default was equally pointless).

## Fix

Belt-and-suspenders, both small:

1. **`Dockerfile`**: remove the empty-string `ENV` defaults for `NATS_SERVER_URL`, `ADMIN_SERVICE_URL`, `TMS_SERVER_URL`, `AUTH_SERVICE_URL`, `NEXTAUTH_SECRET`. The required vars now fail fast at env validation if the caller forgets them (rather than later with a confusing error). The optional vars stay unset so callers can simply omit them. `AUTHENTICATED="false"` is kept so the image is usable out-of-the-box.
2. **`env.mjs`**: coerce empty strings to `undefined` in `runtimeEnv` for the two optional fields. This makes the validation correct even if a future caller (or another container that re-introduces a default) passes `""`.

Either change alone resolves #108; together they prevent the class of bug from recurring.

## Test plan

- `npm test` -> 20 suites, 351 tests, all passing
- Manual: `docker build` + `docker run` with `AUTHENTICATED=false` and no `AUTH_SERVICE_URL`/`NEXTAUTH_SECRET` in env_file -> container starts cleanly (verifies the originally reported failure mode)

Closes #108


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced environment variable validation to ensure required configuration values are explicitly provided, preventing silent configuration failures in deployments.

* **Chores**
  * Updated production Docker configuration to better document and enforce required runtime environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->