### PR TITLE
fix: trust host in NextAuth + skip middleware wrapper when auth disabled

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import NextAuth from "next-auth"
-import CredentialsProvider from "next-auth/providers/credentials"
-import type { JWT } from "next-auth/jwt"
 import type { Session } from "next-auth"
+import type { JWT } from "next-auth/jwt"
+import CredentialsProvider from "next-auth/providers/credentials"
 
 if (process.env.AUTHENTICATED === "true") {
   if (!process.env.NEXTAUTH_SECRET) throw new Error("NEXTAUTH_SECRET is required when AUTHENTICATED=true")
@@ -10,6 +10,12 @@ if (process.env.AUTHENTICATED === "true") {
 }
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
+  // Tazama is always self-hosted (Docker Compose, Helm). NextAuth v5's
+  // host-trust check otherwise fails with UntrustedHost on every request
+  // because no Vercel auto-detect path applies. Setting this here, rather
+  // than relying on an AUTH_TRUST_HOST env var per deployment, makes the
+  // demo work correctly out of the box in any self-hosted environment.
+  trustHost: true,
   providers: [
     CredentialsProvider({
       credentials: {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -15,6 +15,16 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   // because no Vercel auto-detect path applies. Setting this here, rather
   // than relying on an AUTH_TRUST_HOST env var per deployment, makes the
   // demo work correctly out of the box in any self-hosted environment.
+  //
+  // SECURITY NOTE: `trustHost: true` tells Auth.js to accept the
+  // `X-Forwarded-Host` and `X-Forwarded-Proto` headers from the request
+  // when constructing canonical callback/redirect URLs. This is safe
+  // ONLY when the deployment's ingress (the Compose reverse proxy, the
+  // Helm chart's ingress controller, etc.) is the single trusted hop
+  // and strips or overwrites any client-supplied `X-Forwarded-*`
+  // headers before they reach the app. If client-supplied forwarded
+  // headers can reach this process, an attacker can spoof the host and
+  // redirect OAuth callbacks to an arbitrary origin.
   trustHost: true,
   providers: [
     CredentialsProvider({

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,22 +1,32 @@
 // SPDX-License-Identifier: Apache-2.0
-import { auth } from "lib/auth"
 import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
+import { auth } from "lib/auth"
 
 const AUTHENTICATED = process.env.AUTHENTICATED === "true"
 
-// auth() wraps the middleware - when AUTHENTICATED=true it attaches request.auth
-// when the session cookie is valid, otherwise request.auth is null.
-export default auth(function middleware(request: NextRequest & { auth: unknown }) {
-  if (AUTHENTICATED && !request.auth) {
-    // Allow the login page itself through (prevents infinite redirect)
-    if (request.nextUrl.pathname.startsWith("/login")) {
+// When auth is disabled, export a no-op middleware so the NextAuth edge
+// wrapper is never invoked. This avoids pointless work on every request
+// and side-steps any NextAuth-internal checks (host validation, cookie
+// parsing) that have nothing to do with our application logic.
+//
+// When auth is enabled, auth() wraps the middleware: it attaches
+// request.auth when the session cookie is valid, otherwise request.auth
+// is null and we redirect unauthenticated users to /login.
+export default AUTHENTICATED
+  ? auth(function middleware(request: NextRequest & { auth: unknown }) {
+      if (!request.auth) {
+        // Allow the login page itself through (prevents infinite redirect)
+        if (request.nextUrl.pathname.startsWith("/login")) {
+          return NextResponse.next()
+        }
+        return NextResponse.redirect(new URL("/login", request.url))
+      }
+      return NextResponse.next()
+    })
+  : function middleware(_request: NextRequest) {
       return NextResponse.next()
     }
-    return NextResponse.redirect(new URL("/login", request.url))
-  }
-  return NextResponse.next()
-})
 
 export const config = {
   matcher: [

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
+import type { NextAuthRequest } from "next-auth"
 import { auth } from "lib/auth"
 
 const AUTHENTICATED = process.env.AUTHENTICATED === "true"
@@ -11,12 +12,17 @@ const AUTHENTICATED = process.env.AUTHENTICATED === "true"
 // parsing) that have nothing to do with our application logic.
 //
 // When auth is enabled, auth() wraps the middleware: it attaches
-// request.auth when the session cookie is valid, otherwise request.auth
-// is null and we redirect unauthenticated users to /login.
+// request.auth (typed Session | null via NextAuthRequest) when the
+// session cookie is valid, otherwise request.auth is null and we
+// redirect unauthenticated users to /login.
 export default AUTHENTICATED
-  ? auth(function middleware(request: NextRequest & { auth: unknown }) {
+  ? auth(function middleware(request: NextAuthRequest) {
       if (!request.auth) {
-        // Allow the login page itself through (prevents infinite redirect)
+        // Allow the login page itself through (prevents infinite redirect).
+        // `startsWith` rather than `===` is deliberate: any future
+        // sub-route under /login (e.g. /login/forgot-password) must remain
+        // reachable without authentication, otherwise the middleware would
+        // redirect it back to itself.
         if (request.nextUrl.pathname.startsWith("/login")) {
           return NextResponse.next()
         }


### PR DESCRIPTION
## Summary

Two complementary fixes that together resolve the `[auth][error] UntrustedHost: Host must be trusted` errors observed on every page request of the v4 demo deployment, regardless of whether authentication is enabled.

## Background

The v4 demo introduces a top-level `middleware.ts` that wraps every non-`/api` request in NextAuth v5's `auth()` edge wrapper. That wrapper:

1. Performs a **host-trust check** before any application code runs. Because NextAuth's only built-in trust-source is Vercel auto-detection (which never applies to self-hosted Tazama), it refused to trust the request host and emitted `UntrustedHost` on every page load.
2. Was being invoked unconditionally - even when `AUTHENTICATED=false`, the wrapper still ran end-to-end before our `if (AUTHENTICATED && !request.auth)` branch ever got the chance to skip it.

The host-trust failure was visible in the deployment logs as the noisy `[auth][error] UntrustedHost` traces on `/api/auth/session`. The unconditional-wrapping was silent overhead, but compounded the symptom.

## Changes

### Commit 1 - `fix: set trustHost in NextAuth config for self-hosted deployments`

`lib/auth.ts`: add `trustHost: true` to the `NextAuth({...})` configuration.

Tazama is **always** self-hosted (Docker Compose for the demo/sandbox stack, Helm for production - `On-Prem-helm`, `EKS-helm`, `GKE-helm`, `AKS-helm`). The Vercel auto-detect path that NextAuth's host check is designed to protect is not applicable. Setting this in the application config rather than relying on a per-deployment `AUTH_TRUST_HOST=true` environment variable makes the demo work correctly out of the box in every supported deployment topology.

### Commit 2 - `refactor: skip NextAuth middleware wrapper when AUTHENTICATED=false`

`middleware.ts`: gate the `auth()` wrapper on `AUTHENTICATED`. When auth is disabled, export a trivial `NextResponse.next()` pass-through so the NextAuth wrapper is never invoked at all. When auth is enabled, behaviour is unchanged.

This is defence-in-depth complementing the first commit:
- Removes pointless cookie parsing, host validation, and session construction on every request in the unauthenticated case (a small but free perf + clarity win).
- Ensures that if a future regression reintroduces a host-check or similar NextAuth-internal failure, it can only fire in deployments that actually use auth, where it is meaningful.

## Verification

- `npm run lint:eslint` - no new warnings on the touched files; all pre-existing warnings are unchanged.
- `npm test` - 351/351 tests pass.
- `npm run build` - clean production build; middleware bundle reports 85.8 kB (Next.js' standard reporting).

## Deployment impact

- No environment variable changes required.
- No compose / Helm changes required.
- Existing deployments running with `AUTHENTICATED=false` will stop emitting `UntrustedHost` errors on the first request after rollout.
- Existing deployments running with `AUTHENTICATED=true` will also stop emitting `UntrustedHost` errors. Behaviour for authenticated users (redirect to `/login`, session cookie validation, signIn/signOut flows) is unchanged.

## Related

- Surfaced during the v4 deployment audit captured in `tazama-demo-feature-parity-audit.md` (local audit doc).
- Does not address the separate "network map fetch fails silently on cold start" issue observed in the same deployment - that is application-level resilience work to be tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved authentication redirect loop preventing access to login pages
  
* **Improvements**
  * Enhanced authentication configuration for self-hosted deployments with improved host trust settings
  * Made authentication toggleable via environment variables for flexible operational setups
  * Optimized authentication middleware handling for better request routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->