### PR TITLE
feat: make admin-service network-map fetch resilient to cold-start

### DIFF
--- a/__tests__/ConnectionStatusBanner.test.tsx
+++ b/__tests__/ConnectionStatusBanner.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen } from "@testing-library/react"
+import { type ConnectionStatus, ConnectionStatusBanner } from "components/ConnectionStatusBanner/ConnectionStatusBanner"
+
+describe("ConnectionStatusBanner", () => {
+  it("renders nothing when status is idle", () => {
+    const { container } = render(<ConnectionStatusBanner status={{ state: "idle" }} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders nothing when status is connected", () => {
+    const { container } = render(<ConnectionStatusBanner status={{ state: "connected", service: "admin" }} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("shows a connecting message when state is connecting", () => {
+    render(<ConnectionStatusBanner status={{ state: "connecting", service: "admin" }} />)
+    expect(screen.getByRole("status")).toHaveTextContent(/connecting/i)
+  })
+
+  it("shows a retrying message with the attempt number", () => {
+    const status: ConnectionStatus = { state: "retrying", service: "admin", attempt: 3 }
+    render(<ConnectionStatusBanner status={status} />)
+    expect(screen.getByRole("status")).toHaveTextContent(/attempt 3/i)
+  })
+
+  it("shows a failed message when state is failed", () => {
+    render(<ConnectionStatusBanner status={{ state: "failed", service: "admin" }} />)
+    expect(screen.getByRole("alert")).toHaveTextContent(/unable to reach/i)
+  })
+
+  it("identifies the affected service in the banner", () => {
+    render(<ConnectionStatusBanner status={{ state: "retrying", service: "admin", attempt: 2 }} />)
+    expect(screen.getByRole("status")).toHaveTextContent(/admin/i)
+  })
+})

--- a/__tests__/network-map.test.ts
+++ b/__tests__/network-map.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @jest-environment node
+ */
+// SPDX-License-Identifier: Apache-2.0
+
+import { fetchNetworkMapWithRetry } from "lib/network-map"
+
+type FetchNetworkMapResult = { networkMap: unknown; attempts: number }
+
+const ORIGINAL_ADMIN_URL = process.env.ADMIN_SERVICE_URL
+const originalFetch = global.fetch
+
+beforeEach(() => {
+  process.env.ADMIN_SERVICE_URL = "https://admin.example.com"
+})
+
+afterEach(() => {
+  global.fetch = originalFetch
+  if (ORIGINAL_ADMIN_URL === undefined) delete process.env.ADMIN_SERVICE_URL
+  else process.env.ADMIN_SERVICE_URL = ORIGINAL_ADMIN_URL
+  jest.restoreAllMocks()
+})
+
+function okResponse(body: unknown) {
+  return { ok: true, status: 200, json: () => Promise.resolve(body) } as Response
+}
+
+describe("fetchNetworkMapWithRetry", () => {
+  it("resolves with the network-map JSON on first-attempt success", async () => {
+    global.fetch = jest.fn().mockResolvedValue(okResponse({ data: { transactions: [] } })) as unknown as typeof fetch
+
+    const result = await fetchNetworkMapWithRetry({
+      jwt: undefined,
+      backoff: { initialDelayMs: 1, multiplier: 2, maxDelayMs: 10, jitterRatio: 0 },
+    })
+
+    expect(result.networkMap).toEqual({ data: { transactions: [] } })
+    expect(result.attempts).toBe(1)
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it("retries on transport errors and eventually succeeds", async () => {
+    const transport = Object.assign(new TypeError("fetch failed"), { cause: { code: "ECONNREFUSED" } })
+    global.fetch = jest
+      .fn()
+      .mockRejectedValueOnce(transport)
+      .mockRejectedValueOnce(transport)
+      .mockResolvedValue(okResponse({ data: { transactions: [{ id: "tx1" }] } })) as unknown as typeof fetch
+
+    const result = await fetchNetworkMapWithRetry({
+      jwt: undefined,
+      backoff: { initialDelayMs: 1, multiplier: 2, maxDelayMs: 10, jitterRatio: 0 },
+    })
+
+    expect(result.networkMap).toEqual({ data: { transactions: [{ id: "tx1" }] } })
+    expect(result.attempts).toBe(3)
+    expect(global.fetch).toHaveBeenCalledTimes(3)
+  })
+
+  it("treats a non-2xx response as a retryable failure", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 503, json: () => Promise.resolve({}) } as Response)
+      .mockResolvedValueOnce(okResponse({ data: { transactions: [] } })) as unknown as typeof fetch
+
+    const result = await fetchNetworkMapWithRetry({
+      jwt: undefined,
+      backoff: { initialDelayMs: 1, multiplier: 2, maxDelayMs: 10, jitterRatio: 0 },
+    })
+
+    expect(result.attempts).toBe(2)
+  })
+
+  it("invokes onAttempt callback with attempt number and outcome before each retry", async () => {
+    const transport = new TypeError("fetch failed")
+    global.fetch = jest
+      .fn()
+      .mockRejectedValueOnce(transport)
+      .mockResolvedValue(okResponse({})) as unknown as typeof fetch
+    const onAttempt = jest.fn()
+
+    await fetchNetworkMapWithRetry({
+      jwt: undefined,
+      backoff: { initialDelayMs: 1, multiplier: 2, maxDelayMs: 10, jitterRatio: 0 },
+      onAttempt,
+    })
+
+    expect(onAttempt).toHaveBeenCalledWith(expect.objectContaining({ attempt: 1, ok: false }))
+  })
+
+  it("returns null networkMap when ADMIN_SERVICE_URL is unset (no retry)", async () => {
+    delete process.env.ADMIN_SERVICE_URL
+    global.fetch = jest.fn() as unknown as typeof fetch
+
+    const result: FetchNetworkMapResult = await fetchNetworkMapWithRetry({
+      jwt: undefined,
+      backoff: { initialDelayMs: 1, multiplier: 2, maxDelayMs: 10, jitterRatio: 0 },
+    })
+
+    expect(result.networkMap).toBeNull()
+    expect(result.attempts).toBe(0)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it("forwards the JWT as an Authorization header when provided", async () => {
+    const fetchMock = jest.fn().mockResolvedValue(okResponse({})) as unknown as jest.Mock
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    await fetchNetworkMapWithRetry({
+      jwt: "abc.def.ghi",
+      backoff: { initialDelayMs: 1, multiplier: 2, maxDelayMs: 10, jitterRatio: 0 },
+    })
+
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>
+    expect(headers["Authorization"]).toBe("Bearer abc.def.ghi")
+  })
+
+  it("aborts via signal and rejects without further fetch calls", async () => {
+    const ctrl = new AbortController()
+    const fetchMock = jest.fn().mockImplementation(() => {
+      ctrl.abort()
+      return Promise.reject(new TypeError("fetch failed"))
+    }) as unknown as jest.Mock
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    await expect(
+      fetchNetworkMapWithRetry({
+        jwt: undefined,
+        backoff: { initialDelayMs: 1, multiplier: 2, maxDelayMs: 10, jitterRatio: 0 },
+        signal: ctrl.signal,
+      })
+    ).rejects.toThrow(/aborted/i)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/__tests__/network-map.test.ts
+++ b/__tests__/network-map.test.ts
@@ -62,13 +62,21 @@ describe("fetchNetworkMapWithRetry", () => {
       .fn()
       .mockResolvedValueOnce({ ok: false, status: 503, json: () => Promise.resolve({}) } as Response)
       .mockResolvedValueOnce(okResponse({ data: { transactions: [] } })) as unknown as typeof fetch
+    const onAttempt = jest.fn()
 
     const result = await fetchNetworkMapWithRetry({
       jwt: undefined,
       backoff: { initialDelayMs: 1, multiplier: 2, maxDelayMs: 10, jitterRatio: 0 },
+      onAttempt,
     })
 
     expect(result.attempts).toBe(2)
+    // Regression guard: onAttempt must fire exactly once per attempt.
+    // A non-2xx response previously fired both the non-2xx branch and the
+    // catch branch, producing two notifications for one attempt.
+    expect(onAttempt).toHaveBeenCalledTimes(result.attempts)
+    expect(onAttempt).toHaveBeenNthCalledWith(1, expect.objectContaining({ attempt: 1, ok: false, status: 503 }))
+    expect(onAttempt).toHaveBeenNthCalledWith(2, expect.objectContaining({ attempt: 2, ok: true, status: 200 }))
   })
 
   it("invokes onAttempt callback with attempt number and outcome before each retry", async () => {

--- a/__tests__/retry.test.ts
+++ b/__tests__/retry.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @jest-environment node
+ */
+// SPDX-License-Identifier: Apache-2.0
+
+import { computeBackoffDelay, RetryAbortedError, withRetry } from "lib/retry"
+
+interface RetryOptions {
+  initialDelayMs: number
+  multiplier: number
+  maxDelayMs: number
+  jitterRatio: number
+  maxAttempts?: number
+  signal?: AbortSignal
+  onRetry?: (event: { attempt: number; delayMs: number; error: unknown }) => void
+}
+
+// ─── computeBackoffDelay ─────────────────────────────────────────────────────
+
+describe("computeBackoffDelay", () => {
+  it("returns initialDelayMs on attempt 1 with no jitter", () => {
+    const delay = computeBackoffDelay(1, { initialDelayMs: 500, multiplier: 2, maxDelayMs: 30000, jitterRatio: 0 })
+    expect(delay).toBe(500)
+  })
+
+  it("doubles each attempt when multiplier=2 and no jitter", () => {
+    const opts = { initialDelayMs: 500, multiplier: 2, maxDelayMs: 30000, jitterRatio: 0 }
+    expect(computeBackoffDelay(1, opts)).toBe(500)
+    expect(computeBackoffDelay(2, opts)).toBe(1000)
+    expect(computeBackoffDelay(3, opts)).toBe(2000)
+    expect(computeBackoffDelay(4, opts)).toBe(4000)
+    expect(computeBackoffDelay(5, opts)).toBe(8000)
+  })
+
+  it("caps the delay at maxDelayMs", () => {
+    const opts = { initialDelayMs: 500, multiplier: 2, maxDelayMs: 5000, jitterRatio: 0 }
+    expect(computeBackoffDelay(10, opts)).toBe(5000)
+    expect(computeBackoffDelay(100, opts)).toBe(5000)
+  })
+
+  it("returns a value within ±jitterRatio of the base delay", () => {
+    const opts = { initialDelayMs: 1000, multiplier: 2, maxDelayMs: 30000, jitterRatio: 0.2 }
+    for (let i = 0; i < 50; i++) {
+      const delay = computeBackoffDelay(2, opts) // base = 2000
+      expect(delay).toBeGreaterThanOrEqual(1600) // -20%
+      expect(delay).toBeLessThanOrEqual(2400) // +20%
+    }
+  })
+
+  it("never returns a negative delay even when jitter is at the lower bound", () => {
+    const opts = { initialDelayMs: 1, multiplier: 2, maxDelayMs: 30000, jitterRatio: 0.5 }
+    for (let i = 0; i < 50; i++) {
+      expect(computeBackoffDelay(1, opts)).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  it("treats attempt < 1 as attempt = 1", () => {
+    const opts = { initialDelayMs: 500, multiplier: 2, maxDelayMs: 30000, jitterRatio: 0 }
+    expect(computeBackoffDelay(0, opts)).toBe(500)
+    expect(computeBackoffDelay(-5, opts)).toBe(500)
+  })
+})
+
+// ─── withRetry ───────────────────────────────────────────────────────────────
+
+describe("withRetry", () => {
+  const opts: RetryOptions = {
+    initialDelayMs: 1,
+    multiplier: 2,
+    maxDelayMs: 10,
+    jitterRatio: 0,
+    maxAttempts: 3,
+  }
+
+  it("returns the value on first-attempt success", async () => {
+    const fn = jest.fn().mockResolvedValue("ok")
+    const result = await withRetry(fn, opts)
+    expect(result).toBe("ok")
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it("retries on failure and returns the eventual success value", async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValue("ok")
+    const result = await withRetry(fn, opts)
+    expect(result).toBe("ok")
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  it("throws the last error after maxAttempts exhausted (bounded)", async () => {
+    const fn = jest.fn().mockRejectedValue(new Error("boom"))
+    await expect(withRetry(fn, opts)).rejects.toThrow("boom")
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  it("retries indefinitely when maxAttempts is omitted (unbounded)", async () => {
+    let calls = 0
+    const fn = jest.fn().mockImplementation(() => {
+      calls++
+      if (calls < 25) return Promise.reject(new Error("not yet"))
+      return Promise.resolve("ok")
+    })
+    const result = await withRetry(fn, { ...opts, maxAttempts: undefined })
+    expect(result).toBe("ok")
+    expect(calls).toBe(25)
+  })
+
+  it("aborts immediately when the signal is already aborted", async () => {
+    const ctrl = new AbortController()
+    ctrl.abort()
+    const fn = jest.fn().mockResolvedValue("ok")
+    await expect(withRetry(fn, { ...opts, signal: ctrl.signal })).rejects.toBeInstanceOf(RetryAbortedError)
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it("aborts between retries when signal is aborted mid-flight", async () => {
+    const ctrl = new AbortController()
+    const fn = jest.fn().mockImplementation(() => {
+      ctrl.abort()
+      return Promise.reject(new Error("boom"))
+    })
+    await expect(withRetry(fn, { ...opts, signal: ctrl.signal, maxAttempts: 10 })).rejects.toBeInstanceOf(
+      RetryAbortedError
+    )
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it("invokes onRetry with attempt, delayMs, and error metadata", async () => {
+    const fn = jest.fn().mockRejectedValueOnce(new Error("boom")).mockResolvedValue("ok")
+    const onRetry = jest.fn()
+    await withRetry(fn, { ...opts, onRetry })
+    expect(onRetry).toHaveBeenCalledTimes(1)
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attempt: 1,
+        delayMs: expect.any(Number),
+        error: expect.any(Error),
+      })
+    )
+  })
+})

--- a/app/(demo)/page.tsx
+++ b/app/(demo)/page.tsx
@@ -22,7 +22,7 @@ import ProcessorContext from "store/processors/processor.context"
 
 import { Rule, TypoEFRuP, Typology } from "store/processors/processor.interface"
 
-let socket
+let socket: ReturnType<typeof io> | undefined
 const Web = () => {
   const entityCtx = useContext(EntityContext)
   const processCtx = useContext(ProcessorContext)
@@ -204,6 +204,19 @@ const Web = () => {
       }
     }
     socketInitializer()
+    // Cleanup so React Strict Mode re-mounts (dev) do not leak duplicate
+    // sockets and stacked listeners. socketInitializer is async and assigns
+    // the module-scoped `socket` after a network round-trip, so the cleanup
+    // checks for the assignment before tearing down.
+    return () => {
+      if (socket) {
+        socket.off("connect")
+        socket.off("welcome")
+        socket.off("connection:status")
+        socket.off("eventAdjudicator")
+        socket.disconnect()
+      }
+    }
   }, [])
 
   useEffect(() => {

--- a/app/(demo)/page.tsx
+++ b/app/(demo)/page.tsx
@@ -4,6 +4,7 @@ import { DragDropContext } from "@hello-pangea/dnd"
 import Image from "next/image"
 import React, { useContext, useEffect, useState } from "react"
 import io from "socket.io-client"
+import { type ConnectionStatus, ConnectionStatusBanner } from "components/ConnectionStatusBanner/ConnectionStatusBanner"
 import CreditorProfileComponent from "components/CreditorProfileComponent/CreditorProfileComponent"
 import DebtorProfileComponent from "components/DebtorProfileComponent/DebtorProfileComponent"
 import { DebtorDevice } from "components/Device/Debtor"
@@ -18,7 +19,7 @@ import TypeResult from "components/TypologyResults/TypologyResults"
 import EntityContext from "store/entities/entity.context"
 import { CdtrEntity, Entity } from "store/entities/entity.interface"
 import ProcessorContext from "store/processors/processor.context"
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
 import { Rule, TypoEFRuP, Typology } from "store/processors/processor.interface"
 
 let socket
@@ -40,6 +41,7 @@ const Web = () => {
   const [flashing, setFlashing] = useState(false)
   const [flashColor, setFlashColor] = useState<"r" | "g">("r")
   const [displayOverridden, setDisplayOverridden] = useState(false)
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>({ state: "idle" })
 
   useEffect(() => {
     if (hoveredType) {
@@ -189,6 +191,9 @@ const Web = () => {
         })
         socket.on("welcome", (msg) => {
           console.log("received", msg)
+        })
+        socket.on("connection:status", (status: ConnectionStatus) => {
+          setConnectionStatus(status)
         })
         socket.on("eventAdjudicator", async (msg) => {
           if (processCtx.activeMsgId && msg?.transaction?.FIToFIPmtSts?.GrpHdr?.MsgId !== processCtx.activeMsgId) return
@@ -346,6 +351,7 @@ const Web = () => {
 
   return (
     <div className="flex min-h-full w-full flex-col">
+      <ConnectionStatusBanner status={connectionStatus} />
       <div className="z-99 absolute right-[100px] top-5 cursor-pointer">
         <button
           className="content-right-center ml-auto rounded-md bg-gradient-to-b from-gray-100 to-gray-200 p-2 shadow-lg"

--- a/components/ConnectionStatusBanner/ConnectionStatusBanner.module.css
+++ b/components/ConnectionStatusBanner/ConnectionStatusBanner.module.css
@@ -1,0 +1,30 @@
+.banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  padding: 0.5rem 1rem;
+  text-align: center;
+  font-size: 0.875rem;
+  z-index: 9999;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+}
+
+.connecting {
+  background-color: #fff8e1;
+  color: #5d4037;
+  border-bottom: 1px solid #ffe082;
+}
+
+.retrying {
+  background-color: #ffe0b2;
+  color: #4e342e;
+  border-bottom: 1px solid #ffb74d;
+}
+
+.failed {
+  background-color: #ffcdd2;
+  color: #b71c1c;
+  border-bottom: 1px solid #e57373;
+  font-weight: 600;
+}

--- a/components/ConnectionStatusBanner/ConnectionStatusBanner.tsx
+++ b/components/ConnectionStatusBanner/ConnectionStatusBanner.tsx
@@ -1,0 +1,58 @@
+"use client"
+// SPDX-License-Identifier: Apache-2.0
+
+import styles from "./ConnectionStatusBanner.module.css"
+
+export type ConnectionService = "admin"
+
+export type ConnectionStatus =
+  | { state: "idle" }
+  | { state: "connecting"; service: ConnectionService }
+  | { state: "retrying"; service: ConnectionService; attempt: number }
+  | { state: "connected"; service: ConnectionService; attempts?: number }
+  | { state: "failed"; service: ConnectionService }
+
+interface Props {
+  status: ConnectionStatus
+}
+
+const SERVICE_LABEL: Record<ConnectionService, string> = {
+  admin: "admin service",
+}
+
+/**
+ * Non-blocking banner that surfaces the demo session's connection state to
+ * its upstream dependencies (currently just the admin-service network-map
+ * fetch). Hidden in the steady state (idle/connected); visible only when
+ * something requires the user's attention.
+ *
+ * Driven by `connection:status` Socket.IO events emitted by `server.js`.
+ */
+export function ConnectionStatusBanner({ status }: Props) {
+  if (status.state === "idle" || status.state === "connected") {
+    return null
+  }
+
+  if (status.state === "failed") {
+    return (
+      <div role="alert" className={`${styles.banner} ${styles.failed}`}>
+        Unable to reach the {SERVICE_LABEL[status.service]}. Refresh the page to retry.
+      </div>
+    )
+  }
+
+  if (status.state === "retrying") {
+    return (
+      <div role="status" className={`${styles.banner} ${styles.retrying}`}>
+        Reconnecting to the {SERVICE_LABEL[status.service]} (attempt {status.attempt})…
+      </div>
+    )
+  }
+
+  // connecting
+  return (
+    <div role="status" className={`${styles.banner} ${styles.connecting}`}>
+      Connecting to the {SERVICE_LABEL[status.service]}…
+    </div>
+  )
+}

--- a/lib/network-map.js
+++ b/lib/network-map.js
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Resilient admin-service network-map fetch used by `server.js` on each new
+ * Socket.IO session. Wraps a single HTTP GET in `withRetry` so that cold-start
+ * races against the admin-service (Docker `depends_on: service_started` only
+ * waits for process invocation, not readiness) are absorbed transparently.
+ *
+ * The retry is unbounded by default: the session cannot proceed without the
+ * network map, and "still trying" is the correct state to expose to the UI
+ * rather than failing the connection.
+ *
+ * Authored as CommonJS so `server.js` can `require()` it directly.
+ */
+
+const { withRetry } = require("./retry")
+
+const NETWORK_MAP_PATH = "/v1/admin/configuration/network_map?filters[active]=true"
+
+/**
+ * @typedef {import('./retry').BackoffOptions} BackoffOptions
+ * @typedef {{
+ *   jwt: string | undefined,
+ *   backoff: BackoffOptions,
+ *   maxAttempts?: number,
+ *   signal?: AbortSignal,
+ *   onAttempt?: (event: { attempt: number, ok: boolean, status?: number, error?: unknown }) => void,
+ *   requestTimeoutMs?: number,
+ * }} FetchNetworkMapOptions
+ * @typedef {{ networkMap: unknown, attempts: number }} FetchNetworkMapResult
+ */
+
+/**
+ * @param {FetchNetworkMapOptions} opts
+ * @returns {Promise<FetchNetworkMapResult>}
+ */
+async function fetchNetworkMapWithRetry(opts) {
+  const baseUrl = process.env.ADMIN_SERVICE_URL
+  if (!baseUrl) {
+    return { networkMap: null, attempts: 0 }
+  }
+
+  let attempts = 0
+  const headers = { "Content-Type": "application/json" }
+  if (opts.jwt) headers["Authorization"] = `Bearer ${opts.jwt}`
+
+  const networkMap = await withRetry(
+    async () => {
+      attempts++
+      try {
+        const res = await fetch(`${baseUrl}${NETWORK_MAP_PATH}`, {
+          headers,
+          signal: AbortSignal.timeout(opts.requestTimeoutMs == null ? 5000 : opts.requestTimeoutMs),
+        })
+        if (!res.ok) {
+          if (opts.onAttempt) opts.onAttempt({ attempt: attempts, ok: false, status: res.status })
+          throw new Error(`Admin service returned ${res.status} for ${NETWORK_MAP_PATH}`)
+        }
+        const json = await res.json()
+        if (opts.onAttempt) opts.onAttempt({ attempt: attempts, ok: true, status: res.status })
+        return json
+      } catch (err) {
+        if (opts.onAttempt) opts.onAttempt({ attempt: attempts, ok: false, error: err })
+        throw err
+      }
+    },
+    {
+      initialDelayMs: opts.backoff.initialDelayMs,
+      multiplier: opts.backoff.multiplier,
+      maxDelayMs: opts.backoff.maxDelayMs,
+      jitterRatio: opts.backoff.jitterRatio,
+      maxAttempts: opts.maxAttempts,
+      signal: opts.signal,
+    }
+  )
+
+  return { networkMap, attempts }
+}
+
+module.exports = { fetchNetworkMapWithRetry }

--- a/lib/network-map.js
+++ b/lib/network-map.js
@@ -46,22 +46,33 @@ async function fetchNetworkMapWithRetry(opts) {
   const networkMap = await withRetry(
     async () => {
       attempts++
+      // Each attempt must invoke opts.onAttempt exactly once. To guarantee
+      // that, we keep the transport-error path (fetch threw), the non-2xx
+      // response path, and the JSON-parse-failure path separate, and only
+      // notify success once we have a parsed body.
+      let res
       try {
-        const res = await fetch(`${baseUrl}${NETWORK_MAP_PATH}`, {
+        res = await fetch(`${baseUrl}${NETWORK_MAP_PATH}`, {
           headers,
           signal: AbortSignal.timeout(opts.requestTimeoutMs == null ? 5000 : opts.requestTimeoutMs),
         })
-        if (!res.ok) {
-          if (opts.onAttempt) opts.onAttempt({ attempt: attempts, ok: false, status: res.status })
-          throw new Error(`Admin service returned ${res.status} for ${NETWORK_MAP_PATH}`)
-        }
-        const json = await res.json()
-        if (opts.onAttempt) opts.onAttempt({ attempt: attempts, ok: true, status: res.status })
-        return json
       } catch (err) {
         if (opts.onAttempt) opts.onAttempt({ attempt: attempts, ok: false, error: err })
         throw err
       }
+      if (!res.ok) {
+        if (opts.onAttempt) opts.onAttempt({ attempt: attempts, ok: false, status: res.status })
+        throw new Error(`Admin service returned ${res.status} for ${NETWORK_MAP_PATH}`)
+      }
+      let json
+      try {
+        json = await res.json()
+      } catch (err) {
+        if (opts.onAttempt) opts.onAttempt({ attempt: attempts, ok: false, status: res.status, error: err })
+        throw err
+      }
+      if (opts.onAttempt) opts.onAttempt({ attempt: attempts, ok: true, status: res.status })
+      return json
     },
     {
       initialDelayMs: opts.backoff.initialDelayMs,

--- a/lib/retry.js
+++ b/lib/retry.js
@@ -13,6 +13,8 @@
  * without a TypeScript loader) can `require()` it directly.
  */
 
+const crypto = require("crypto")
+
 class RetryAbortedError extends Error {
   constructor(message = "retry aborted") {
     super(message)
@@ -47,7 +49,14 @@ function computeBackoffDelay(attempt, opts) {
   const base = Math.min(opts.initialDelayMs * Math.pow(opts.multiplier, n - 1), opts.maxDelayMs)
   if (opts.jitterRatio <= 0) return base
   const spread = base * opts.jitterRatio
-  const jittered = base + (Math.random() * 2 - 1) * spread
+  // Use crypto.randomInt for the uniform sample instead of Math.random.
+  // The jitter value is non-security (it only decorrelates retry timing
+  // across concurrent clients to avoid thundering herds), but using a CSPRNG
+  // satisfies static analysers (GHAS / nodejsscan) that flag Math.random as
+  // a weak RNG without us having to maintain per-call suppressions. The cost
+  // is negligible compared to the setTimeout sleep that follows.
+  const uniform = crypto.randomInt(0, 0x100000000) / 0x100000000
+  const jittered = base + (uniform * 2 - 1) * spread
   return Math.max(0, Math.round(jittered))
 }
 

--- a/lib/retry.js
+++ b/lib/retry.js
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Retry helper with exponential backoff and jitter.
+ *
+ * Used by the demo server to make best-effort dependent-service calls
+ * (currently the admin-service network-map fetch on session start) survive
+ * cold-start races where the dependency is reachable on the network but not
+ * yet listening.
+ *
+ * Pure: no I/O beyond `setTimeout` and the caller-supplied function.
+ *
+ * Authored as CommonJS so that `server.js` (which runs under raw `node`
+ * without a TypeScript loader) can `require()` it directly.
+ */
+
+class RetryAbortedError extends Error {
+  constructor(message = "retry aborted") {
+    super(message)
+    this.name = "RetryAbortedError"
+  }
+}
+
+/**
+ * @typedef {Object} BackoffOptions
+ * @property {number} initialDelayMs Delay before the first retry, in ms.
+ * @property {number} multiplier Multiplier applied between consecutive retries.
+ * @property {number} maxDelayMs Upper bound for any single retry delay.
+ * @property {number} jitterRatio Fractional jitter (e.g. 0.2 = ±20%). 0 disables.
+ */
+
+/**
+ * @typedef {BackoffOptions & {
+ *   maxAttempts?: number,
+ *   signal?: AbortSignal,
+ *   onRetry?: (event: { attempt: number, delayMs: number, error: unknown }) => void,
+ * }} RetryOptions
+ */
+
+/**
+ * Computes the delay (in ms) before the Nth retry attempt.
+ * @param {number} attempt 1-based attempt index (1 = first retry).
+ * @param {BackoffOptions} opts
+ * @returns {number}
+ */
+function computeBackoffDelay(attempt, opts) {
+  const n = attempt < 1 ? 1 : attempt
+  const base = Math.min(opts.initialDelayMs * Math.pow(opts.multiplier, n - 1), opts.maxDelayMs)
+  if (opts.jitterRatio <= 0) return base
+  const spread = base * opts.jitterRatio
+  const jittered = base + (Math.random() * 2 - 1) * spread
+  return Math.max(0, Math.round(jittered))
+}
+
+/**
+ * @param {number} ms
+ * @param {AbortSignal} [signal]
+ * @returns {Promise<void>}
+ */
+function sleep(ms, signal) {
+  return new Promise((resolve, reject) => {
+    if (signal && signal.aborted) {
+      reject(new RetryAbortedError())
+      return
+    }
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(new RetryAbortedError())
+    }
+    const timer = setTimeout(() => {
+      if (signal) signal.removeEventListener("abort", onAbort)
+      resolve()
+    }, ms)
+    if (signal) signal.addEventListener("abort", onAbort, { once: true })
+  })
+}
+
+/**
+ * Runs `fn`, retrying with exponential-backoff-with-jitter delays on each
+ * thrown error. Resolves with the first successful value. Rejects with:
+ *   - RetryAbortedError if `opts.signal` is aborted (before or between attempts).
+ *   - the most recent thrown error if `opts.maxAttempts` is reached.
+ *
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @param {RetryOptions} opts
+ * @returns {Promise<T>}
+ */
+async function withRetry(fn, opts) {
+  if (opts.signal && opts.signal.aborted) {
+    throw new RetryAbortedError()
+  }
+  let attempt = 0
+  let lastError
+  while (true) {
+    attempt++
+    try {
+      return await fn()
+    } catch (err) {
+      lastError = err
+      if (opts.signal && opts.signal.aborted) {
+        throw new RetryAbortedError()
+      }
+      if (opts.maxAttempts !== undefined && attempt >= opts.maxAttempts) {
+        throw lastError
+      }
+      const delayMs = computeBackoffDelay(attempt, opts)
+      if (opts.onRetry) opts.onRetry({ attempt, delayMs, error: err })
+      await sleep(delayMs, opts.signal)
+    }
+  }
+}
+
+module.exports = { computeBackoffDelay, withRetry, RetryAbortedError }

--- a/server.js
+++ b/server.js
@@ -12,6 +12,8 @@ const { Server } = require("socket.io")
 const { createServer } = require("http")
 const { parse } = require("url")
 const { extractTenant } = require("@tazama-lf/auth-lib")
+const { fetchNetworkMapWithRetry } = require("./lib/network-map")
+const { RetryAbortedError } = require("./lib/retry")
 
 // ---------------------------------------------------------------------------
 // Config
@@ -64,28 +66,78 @@ const tenantSubs = new Map()
 
 // ---------------------------------------------------------------------------
 // Network map fetching
+//
+// Wraps `lib/network-map.js` (retry-with-backoff) so that cold-start races
+// against the admin-service are absorbed transparently. The retry is
+// unbounded - a new Socket.IO session cannot proceed without a network map,
+// and "still trying" is the correct state to expose to the client. The
+// caller passes its socket so per-attempt status can be emitted as a
+// `connection:status` event for the UI to render.
 // ---------------------------------------------------------------------------
+
+/** Default backoff: 500ms ÷ 2x ÷ 30s cap ÷ ±20% jitter. */
+const NETWORK_MAP_BACKOFF = {
+  initialDelayMs: 500,
+  multiplier: 2,
+  maxDelayMs: 30000,
+  jitterRatio: 0.2,
+}
+
 /**
- * Fetches the network map from admin-service.
+ * Fetches the network map from admin-service with unbounded retry. Emits
+ * `connection:status` events to `socket` so the UI can render a banner.
  * @param {string | undefined} jwt
+ * @param {import('socket.io').Socket} [socket]
  * @returns {Promise<object | null>}
  */
-async function fetchNetworkMap(jwt) {
-  if (!ADMIN_SERVICE_URL) return null
+async function fetchNetworkMap(jwt, socket) {
+  if (socket) socket.emit("connection:status", { state: "connecting", service: "admin" })
+
+  // Abort the unbounded retry loop if the client disconnects before we land
+  // a network map. Without this, a flaky client could leave the server in an
+  // unbounded fetch loop for a session that no longer exists.
+  let abortController
+  if (socket) {
+    abortController = new AbortController()
+    socket.once("disconnect", () => abortController.abort())
+  }
+
   try {
-    const headers = { "Content-Type": "application/json" }
-    if (jwt) headers["Authorization"] = `Bearer ${jwt}`
-    const res = await fetch(`${ADMIN_SERVICE_URL}/v1/admin/configuration/network_map?filters[active]=true`, {
-      headers,
-      signal: AbortSignal.timeout(5000),
+    const { networkMap, attempts } = await fetchNetworkMapWithRetry({
+      jwt,
+      backoff: NETWORK_MAP_BACKOFF,
+      signal: abortController ? abortController.signal : undefined,
+      onAttempt: (event) => {
+        if (!event.ok) {
+          console.error(
+            `Network-map fetch attempt ${event.attempt} failed:`,
+            event.error ? event.error.message || String(event.error) : `HTTP ${event.status}`
+          )
+          if (socket && event.attempt > 1) {
+            socket.emit("connection:status", {
+              state: "retrying",
+              service: "admin",
+              attempt: event.attempt,
+            })
+          }
+        }
+      },
     })
-    if (!res.ok) {
-      console.error(`Admin service returned ${res.status} fetching network map`)
+    if (socket) {
+      socket.emit("connection:status", {
+        state: "connected",
+        service: "admin",
+        attempts,
+      })
+    }
+    return networkMap
+  } catch (err) {
+    if (err instanceof RetryAbortedError) {
+      if (socket) socket.emit("connection:status", { state: "failed", service: "admin" })
       return null
     }
-    return await res.json()
-  } catch (err) {
-    console.error("Failed to fetch network map:", err.message)
+    console.error("Failed to fetch network map:", err && err.message ? err.message : err)
+    if (socket) socket.emit("connection:status", { state: "failed", service: "admin" })
     return null
   }
 }
@@ -407,7 +459,7 @@ app.prepare().then(() => {
     socket.emit("welcome", { message: "NATS Connected" })
 
     // Derive subscription subjects from tenant-specific network map
-    const networkMap = await fetchNetworkMap(jwt)
+    const networkMap = await fetchNetworkMap(jwt, socket)
     const { ruleSubjects, typoSubjects } = deriveSubjectsFromNetworkMap(networkMap)
 
     if (nc) {

--- a/server.js
+++ b/server.js
@@ -458,23 +458,12 @@ app.prepare().then(() => {
     console.log("Client connected", socket.id, "tenantId:", tenantId)
     socket.emit("welcome", { message: "NATS Connected" })
 
-    // Derive subscription subjects from tenant-specific network map
-    const networkMap = await fetchNetworkMap(jwt, socket)
-    const { ruleSubjects, typoSubjects } = deriveSubjectsFromNetworkMap(networkMap)
-
-    if (nc) {
-      for (const sub of ruleSubjects) ensureGlobalSub(sub, "ruleResponse", io)
-      for (const sub of typoSubjects) ensureGlobalSub(sub, "typoResponse", io)
-
-      if (tenantId != null) {
-        if (ALERT_DESTINATION === "tenant") ensureTenantSub(ALERT_PRODUCER, tenantId, "eventAdjudicator", io)
-        if (TP_INTERDICTION_DESTINATION === "tenant")
-          ensureTenantSub(TP_INTERDICTION_PRODUCER, tenantId, "interdiction-service-tp", io)
-        if (EF_INTERDICTION_DESTINATION === "tenant")
-          ensureTenantSub(EF_INTERDICTION_PRODUCER, tenantId, "interdiction-service-ef", io)
-      }
-    }
-
+    // Register socket event listeners up-front so they are active during the
+    // (potentially long, unbounded) network-map fetch below. Otherwise events
+    // arriving during cold-start would be dropped. The disconnect handler's
+    // tenant-sub cleanup is idempotent: releaseTenantSub is a no-op if no
+    // tenant subscription was registered for this socket yet, so it remains
+    // safe to fire even if disconnect happens before fetchNetworkMap returns.
     socket.on("confirmation", (message) => {
       console.log("Confirmed:", message)
     })
@@ -492,6 +481,23 @@ app.prepare().then(() => {
         if (EF_INTERDICTION_DESTINATION === "tenant") releaseTenantSub(EF_INTERDICTION_PRODUCER, tenantId)
       }
     })
+
+    // Derive subscription subjects from tenant-specific network map
+    const networkMap = await fetchNetworkMap(jwt, socket)
+    const { ruleSubjects, typoSubjects } = deriveSubjectsFromNetworkMap(networkMap)
+
+    if (nc) {
+      for (const sub of ruleSubjects) ensureGlobalSub(sub, "ruleResponse", io)
+      for (const sub of typoSubjects) ensureGlobalSub(sub, "typoResponse", io)
+
+      if (tenantId != null) {
+        if (ALERT_DESTINATION === "tenant") ensureTenantSub(ALERT_PRODUCER, tenantId, "eventAdjudicator", io)
+        if (TP_INTERDICTION_DESTINATION === "tenant")
+          ensureTenantSub(TP_INTERDICTION_PRODUCER, tenantId, "interdiction-service-tp", io)
+        if (EF_INTERDICTION_DESTINATION === "tenant")
+          ensureTenantSub(EF_INTERDICTION_PRODUCER, tenantId, "interdiction-service-ef", io)
+      }
+    }
   })
 
   server.listen(port, (err) => {


### PR DESCRIPTION
## Summary

Makes the demo's session-start admin-service network-map fetch resilient to cold-start races, and surfaces what's happening to the user via a non-blocking banner. Implements the scope agreed in the v4 deployment-resilience discussion (June 2026).

## Problem

`server.js → fetchNetworkMap` was a single `fetch` against `${ADMIN_SERVICE_URL}/v1/admin/configuration/network_map?filters[active]=true` with no retry, no backoff, no UI surface. When the admin-service container was "started" per Docker Compose's `depends_on: service_started` but not yet listening (which `depends_on` cannot detect), the fetch failed with `fetch failed`, the function silently returned `null`, and the session degraded to "no rules, no typologies, nothing on screen" with no explanation.

Cold-start races are common in compose stacks where the admin-service is itself transitively waiting on Postgres to accept connections. Service-readiness healthchecks for distroless images are tracked separately in [Full-Stack-Docker-Tazama#230](https://github.com/tazama-lf/Full-Stack-Docker-Tazama/issues/230) and are intentionally NOT a prerequisite for this PR; this work treats orchestration as advisory and handles cold-start in-app.

## Changes

### `feat: add retry helper with exponential backoff and jitter` (`lib/retry.js`)

New CommonJS module - `server.js` runs under raw `node` with no TS loader, so a `.ts` file would not be `require()`able. Types declared via JSDoc.

- `computeBackoffDelay(attempt, opts)` - pure function for the delay curve. Deterministically testable without `setTimeout` mocking.
- `withRetry(fn, opts)` - exponential-backoff retry wrapper. Supports both bounded (`maxAttempts`) and unbounded (default) retry. `AbortSignal` aware: throws `RetryAbortedError` before the first attempt or between attempts, and cancels the inter-attempt `sleep` immediately.
- `onRetry` callback for structured logging.

### `feat: add resilient network-map fetch using retry helper` (`lib/network-map.js`)

Wraps the existing admin-service GET in `withRetry`.

- Unbounded retry by default - cold-start is unbounded by nature; the session is blocked on it anyway, so a bounded budget would just convert a recoverable race into a hard failure.
- Treats both transport errors and non-2xx HTTP responses as retryable.
- `onAttempt` callback so callers can surface progress.
- No-op when `ADMIN_SERVICE_URL` is unset (preserves existing behaviour).

### `feat: emit connection:status from server and render banner in UI`

- `server.js`: replaces the inline `fetchNetworkMap` with a call to the new helper. Ties the unbounded retry to the client's socket via an `AbortController` so a disconnect cancels the loop.
- New `connection:status` Socket.IO event with shape `{ state: "connecting" | "retrying" | "connected" | "failed", service: "admin", attempt?, attempts? }`.
- New `ConnectionStatusBanner` component listens for that event and shows a top-of-page banner during `connecting` / `retrying` / `failed`. Hidden in steady state (idle / connected).
- Degraded-serve: a failed fetch surfaces the banner but does not block the page; cached/static content continues to render. Matches the demo's intent (showcase, not gating).

## Default backoff values (in `server.js`)

| Setting | Value |
|---|---|
| `initialDelayMs` | 500 |
| `multiplier` | 2 |
| `maxDelayMs` | 30 000 |
| `jitterRatio` | 0.2 (±20%) |
| `maxAttempts` | unbounded |
| per-attempt request timeout | 5 000 ms |

Worst-case sequence: 500 → 1 000 → 2 000 → 4 000 → 8 000 → 16 000 → 30 000 → 30 000 → ... ms (with ±20% jitter).

## Verification

- `npm test` - **377 / 377 passing** across **23 suites** (was 351 / 351 across 20). 26 new tests:
  - 13 in `__tests__/retry.test.ts` covering backoff math, bounded/unbounded retry, abort, and the `onRetry` callback.
  - 7 in `__tests__/network-map.test.ts` covering success, transport-error retry, non-2xx retry, JWT forwarding, unset URL, abort, and the `onAttempt` callback.
  - 6 in `__tests__/ConnectionStatusBanner.test.tsx` covering each render state.
- `npm run lint:eslint` - no new warnings on the touched files. Pre-existing warnings on other files are unchanged.
- `npm run build` - clean production build; middleware bundle unchanged at 85.8 kB.
- `get_errors` on all touched files - clean.

## Explicitly out of scope (tracked separately)

- TMS POST `/transaction` resilience - intentionally NOT retried. The current fail-fast behaviour is correct: TMS is only invoked on user click, and a duplicate-suppression scenario is being scoped separately in [#112](https://github.com/tazama-lf/tazama-demo/issues/112).
- Steady-state network-map refresh / polling - not done. Network map is fetched once per session and immutable thereafter.
- Drift detection of evaluation-result network map vs cached one - [#110](https://github.com/tazama-lf/tazama-demo/issues/110).
- Compose service-readiness healthchecks for distroless images - [Full-Stack-Docker-Tazama#230](https://github.com/tazama-lf/Full-Stack-Docker-Tazama/issues/230).
- Metrics / Prometheus instrumentation - logs only for now.

## Related

- Companion to [#111](https://github.com/tazama-lf/tazama-demo/pull/111) (UntrustedHost fix), which addresses a different symptom of the same v4 deployment audit.
- Issues [#110](https://github.com/tazama-lf/tazama-demo/issues/110) and [#112](https://github.com/tazama-lf/tazama-demo/issues/112) plus [Full-Stack-Docker-Tazama#230](https://github.com/tazama-lf/Full-Stack-Docker-Tazama/issues/230) are the deliberately-deferred follow-ups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added connection status banner providing real-time visibility into connecting, retrying, and failed states
  * Implemented automatic network request retries with exponential backoff and jitter

* **Tests**
  * Added comprehensive test coverage for connection status display, retry logic, and backoff calculations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->