### PR TITLE
fix: copy lib/ into runtime Docker stage so server.js can require it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,11 @@ COPY --from=builder /app/public ./public
 COPY --from=builder /app/server.js ./server.js
 COPY --from=builder /app/next.config.mjs ./next.config.mjs
 COPY --from=builder /app/env.mjs ./env.mjs
+# server.js is plain CommonJS and is not bundled by Next; any module it
+# requires at runtime (currently the resilient network-map fetch and the
+# retry helper in lib/) must be copied into the runtime image explicitly.
+# Without this, the container crashes on startup with
+# "Cannot find module './lib/network-map'".
+COPY --from=builder /app/lib ./lib
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
## Problem

The runtime stage of [`Dockerfile`](Dockerfile) on `dev` does not copy `lib/` from the builder stage, so containers built from current `dev` crash on startup with:

```
Error: Cannot find module './lib/network-map'
Require stack:
 - /app/server.js
```

This is a follow-on to PR #113 (network-map resilience). That PR added two CommonJS modules - [`lib/network-map.js`](lib/network-map.js) and [`lib/retry.js`](lib/retry.js) - which [`server.js`](server.js) loads at runtime via `require`. Because `server.js` is plain CJS executed by raw `node` (not bundled into `.next/` by Next), those requires resolve against the runtime filesystem, which never received `lib/`.

The fix was committed to the `feat/network-map-fetch-resilience` branch as `2dd9efa`, but the push landed **after** PR #113 was merged, so the commit is sitting on the branch but never made it into `dev`. This PR brings it across.

This is the same root cause as #107 (the `env.mjs` incident) - a new top-level file/directory is required at runtime but the runtime stage's explicit per-file COPY list was not updated. Tracking issue #114 proposes adopting `output: "standalone"` to eliminate the entire class.

## Change

One-line addition to the runtime stage:

```dockerfile
# server.js is plain CommonJS and is not bundled by Next; any module it
# requires at runtime (currently the resilient network-map fetch and the
# retry helper in lib/) must be copied into the runtime image explicitly.
# Without this, the container crashes on startup with
# "Cannot find module './lib/network-map'".
COPY --from=builder /app/lib ./lib
```

The three TS files in `lib/` (`auth.ts`, `nats-helpers.ts`, `tazama-client.ts`) are also copied but never executed at runtime - they are bundled into `.next/` by Next during the build stage. Copying the whole directory rather than enumerating individual files avoids needing another Dockerfile change every time `server.js` gains a new `require` from `lib/`.

## Validation

- `git diff dev` shows only the 6-line Dockerfile addition.
- Hadolint passes (no new rule triggers).
- The fix is identical to the original commit on the resilience branch (`git cherry-pick 2dd9efa`).

## References

- PR #113 (the change that introduced the missing requires)
- Issue #107 / PR (the prior recurrence with `env.mjs`)
- Issue #114 (proposal to adopt `output: "standalone"` to prevent recurrence)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential application startup failures by ensuring all required runtime dependencies are properly included in the production deployment environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->