### PR TITLE
fix: transform admin-service response in /api/network-map so UI can read it

### DIFF
--- a/__tests__/bff-network-map-auth.test.ts
+++ b/__tests__/bff-network-map-auth.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment node
+ */
+// SPDX-License-Identifier: Apache-2.0
+//
+// Companion to bff-network-map.test.ts.
+//
+// Lives in a separate file because the AUTHENTICATED branch of the route
+// requires (a) `process.env.AUTHENTICATED === "true"` at module-load time
+// (it is captured as a const), and (b) the `auth()` call to return a
+// session containing an `accessToken`. Doing this in the same file as the
+// unauthenticated tests is unreliable because top-level `jest.mock` calls
+// are hoisted and win over later `jest.doMock` overrides, leaving the
+// authenticated paths impossible to exercise from the same module scope.
+//
+// NOTE: we use `require()` for the route (after setting AUTHENTICATED=true)
+// because TypeScript hoists `import` statements above any top-level
+// statements, so a plain `import { GET }` would load the route module
+// before our env assignment takes effect.
+
+process.env.SKIP_ENV_VALIDATION = "1"
+process.env.AUTHENTICATED = "true"
+
+jest.mock("lib/auth", () => ({
+  auth: jest.fn(),
+}))
+
+jest.mock("lib/tazama-client", () => {
+  class TazamaClientError extends Error {
+    status: number
+    constructor(status: number, message: string) {
+      super(message)
+      this.status = status
+    }
+  }
+  return { adminGet: jest.fn(), TazamaClientError }
+})
+
+const { auth } = require("lib/auth") as { auth: jest.Mock }
+
+const { adminGet } = require("lib/tazama-client") as { adminGet: jest.Mock }
+
+const { GET } = require("app/api/network-map/route") as { GET: () => Promise<Response> }
+
+beforeEach(() => {
+  auth.mockReset()
+  adminGet.mockReset()
+})
+
+describe("GET /api/network-map - authenticated branch", () => {
+  it("forwards the session JWT to all three admin-service calls", async () => {
+    auth.mockResolvedValue({ accessToken: "test-jwt" })
+    adminGet.mockResolvedValue({ data: [] })
+
+    const response = await GET()
+    expect(response.status).toBe(200)
+
+    // All three admin endpoints must be hit, and each call must receive the
+    // session JWT as the second positional argument.
+    expect(adminGet).toHaveBeenCalledTimes(3)
+    const paths = adminGet.mock.calls.map((c) => c[0] as string)
+    expect(paths).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("/v1/admin/configuration/network_map"),
+        expect.stringContaining("/v1/admin/configuration/rule"),
+        expect.stringContaining("/v1/admin/configuration/typology"),
+      ])
+    )
+    for (const call of adminGet.mock.calls) {
+      expect(call[1]).toBe("test-jwt")
+    }
+  })
+
+  it("short-circuits with 401 and makes no upstream calls when no session exists", async () => {
+    auth.mockResolvedValue(null)
+
+    const response = await GET()
+    expect(response.status).toBe(401)
+    expect(adminGet).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/bff-network-map.test.ts
+++ b/__tests__/bff-network-map.test.ts
@@ -27,16 +27,77 @@ beforeEach(() => {
 })
 
 describe("GET /api/network-map", () => {
-  it("returns 200 with data from adminGet on success", async () => {
-    const fixture = { data: [{ messages: [] }], rules: [], typologies: [] }
-    mockAdminGet.mockResolvedValueOnce(fixture)
+  it("returns 200 with transformed { rules, typologies, typologiesEFRuP } on success", async () => {
+    // First call -> network_map; second -> rule; third -> typology.
+    mockAdminGet
+      .mockResolvedValueOnce({
+        data: [
+          {
+            active: true,
+            messages: [
+              {
+                typologies: [
+                  {
+                    cfg: "999@1.0.0",
+                    rules: [{ id: "901@1.0.0" }, { id: "EFRuP@1.0.0" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: "901@1.0.0", desc: "Rule 901", config: { bands: [] } }],
+      })
+      .mockResolvedValueOnce({
+        data: [
+          { cfg: "999@1.0.0", desc: "Typology 999", workflow: { interdictionThreshold: 100, alertThreshold: 50 } },
+        ],
+      })
 
     const response = await GET()
     const body = await response.json()
 
     expect(response.status).toBe(200)
-    expect(body).toEqual(fixture)
-    expect(mockAdminGet).toHaveBeenCalledWith(expect.stringContaining("/v1/admin/configuration/network_map"), undefined)
+    expect(body).toHaveProperty("rules")
+    expect(body).toHaveProperty("typologies")
+    expect(body).toHaveProperty("typologiesEFRuP")
+    expect(Array.isArray(body.rules)).toBe(true)
+    expect(Array.isArray(body.typologies)).toBe(true)
+    expect(Array.isArray(body.typologiesEFRuP)).toBe(true)
+    expect(body.typologies).toHaveLength(1)
+    expect(body.typologies[0].typoDescription).toBe("Typology 999")
+    expect(body.typologies[0].workflow).toEqual({ interdictionThreshold: 100, alertThreshold: 50 })
+    expect(body.rules).toHaveLength(2)
+    // EFRuP is moved to the end.
+    expect(body.rules[body.rules.length - 1].title).toBe("EFRuP")
+    expect(body.typologiesEFRuP).toEqual([{ typology: "999", efrupResult: undefined }])
+  })
+
+  it("calls all three admin endpoints in parallel with the JWT", async () => {
+    mockAdminGet.mockResolvedValue({ data: [] })
+
+    await GET()
+
+    const calls = mockAdminGet.mock.calls.map((c) => c[0])
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("/v1/admin/configuration/network_map"),
+        expect.stringContaining("/v1/admin/configuration/rule"),
+        expect.stringContaining("/v1/admin/configuration/typology"),
+      ])
+    )
+  })
+
+  it("returns empty arrays when admin-service has no active network map", async () => {
+    mockAdminGet.mockResolvedValue({ data: [] })
+
+    const response = await GET()
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ rules: [], typologies: [], typologiesEFRuP: [] })
   })
 
   it("mirrors the status code from TazamaClientError", async () => {

--- a/__tests__/network-map-transform.test.ts
+++ b/__tests__/network-map-transform.test.ts
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+import { transformNetworkMap } from "lib/network-map-transform"
+
+describe("transformNetworkMap", () => {
+  it("returns empty arrays when there is no active network map", () => {
+    const out = transformNetworkMap({ data: [] }, { data: [] }, { data: [] })
+    expect(out).toEqual({ rules: [], typologies: [], typologiesEFRuP: [] })
+  })
+
+  it("returns empty arrays when inputs are null or undefined", () => {
+    expect(transformNetworkMap(null, null, null)).toEqual({ rules: [], typologies: [], typologiesEFRuP: [] })
+    expect(transformNetworkMap(undefined, undefined, undefined)).toEqual({
+      rules: [],
+      typologies: [],
+      typologiesEFRuP: [],
+    })
+  })
+
+  it("walks messages[].typologies[].rules[] and produces flat arrays", () => {
+    const networkMap = {
+      data: [
+        {
+          messages: [
+            {
+              typologies: [
+                {
+                  cfg: "999@1.0.0",
+                  rules: [{ id: "901@1.0.0" }, { id: "902@1.0.0" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    const out = transformNetworkMap(networkMap, { data: [] }, { data: [] })
+
+    expect(out.rules).toHaveLength(2)
+    expect(out.rules.map((r) => r.title).sort()).toEqual(["901", "902"])
+    expect(out.typologies).toHaveLength(1)
+    expect(out.typologies[0].title).toBe("999")
+    expect(out.typologies[0].linkedRules).toEqual(["901", "902"])
+    expect(out.typologiesEFRuP).toEqual([])
+  })
+
+  it("de-duplicates the EFRuP rule across multiple typologies and pushes one entry to typologiesEFRuP per occurrence", () => {
+    const networkMap = {
+      data: [
+        {
+          messages: [
+            {
+              typologies: [
+                { cfg: "999@1.0.0", rules: [{ id: "EFRuP@1.0.0" }, { id: "901@1.0.0" }] },
+                { cfg: "998@1.0.0", rules: [{ id: "EFRuP@1.0.0" }, { id: "902@1.0.0" }] },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    const out = transformNetworkMap(networkMap, { data: [] }, { data: [] })
+
+    const efrupCount = out.rules.filter((r) => r.title === "EFRuP").length
+    expect(efrupCount).toBe(1)
+    expect(out.typologiesEFRuP).toHaveLength(2)
+    expect(out.typologiesEFRuP.map((t) => t.typology).sort()).toEqual(["998", "999"])
+  })
+
+  it("places the EFRuP rule at the end of the rules list and forces its description", () => {
+    const networkMap = {
+      data: [
+        {
+          messages: [
+            {
+              typologies: [
+                { cfg: "999@1.0.0", rules: [{ id: "EFRuP@1.0.0" }, { id: "901@1.0.0" }, { id: "902@1.0.0" }] },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    const out = transformNetworkMap(networkMap, { data: [] }, { data: [] })
+
+    expect(out.rules[out.rules.length - 1].title).toBe("EFRuP")
+    expect(out.rules[out.rules.length - 1].ruleDescription).toBe("Event Flow Rule Processor")
+  })
+
+  it("hydrates rules with description and bands from the rule list", () => {
+    const networkMap = {
+      data: [
+        {
+          messages: [{ typologies: [{ cfg: "999@1.0.0", rules: [{ id: "901@1.0.0" }] }] }],
+        },
+      ],
+    }
+    const rules = {
+      data: [
+        {
+          id: "901@1.0.0",
+          desc: "Big-number rule",
+          config: {
+            bands: [
+              { subRuleRef: ".01", lowerLimit: 0, upperLimit: 100, reason: "low" },
+              { subRuleRef: ".02", lowerLimit: 100, upperLimit: 1000, reason: "high" },
+            ],
+          },
+        },
+      ],
+    }
+
+    const out = transformNetworkMap(networkMap, rules, { data: [] })
+
+    expect(out.rules[0].ruleDescription).toBe("Big-number rule")
+    expect(out.rules[0].ruleBands).toHaveLength(2)
+    expect(out.rules[0].ruleBands[0]).toEqual({ subRuleRef: ".01", lowerLimit: 0, upperLimit: 100, reason: "low" })
+  })
+
+  it("hydrates rules from the `cases` config shape", () => {
+    const networkMap = {
+      data: [{ messages: [{ typologies: [{ cfg: "999@1.0.0", rules: [{ id: "901@1.0.0" }] }] }] }],
+    }
+    const rules = {
+      data: [
+        {
+          id: "901@1.0.0",
+          desc: "Cases rule",
+          config: { cases: [{ subRuleRef: ".01", lowerLimit: null, upperLimit: null, reason: "match" }] },
+        },
+      ],
+    }
+
+    const out = transformNetworkMap(networkMap, rules, { data: [] })
+
+    expect(out.rules[0].ruleBands).toEqual([{ subRuleRef: ".01", lowerLimit: null, upperLimit: null, reason: "match" }])
+  })
+
+  it("appends `exitConditions` to ruleBands in addition to bands/cases", () => {
+    const networkMap = {
+      data: [{ messages: [{ typologies: [{ cfg: "999@1.0.0", rules: [{ id: "901@1.0.0" }] }] }] }],
+    }
+    const rules = {
+      data: [
+        {
+          id: "901@1.0.0",
+          desc: "Mixed rule",
+          config: {
+            bands: [{ subRuleRef: ".01", lowerLimit: 0, upperLimit: 10, reason: "low" }],
+            exitConditions: [{ subRuleRef: ".exit", lowerLimit: null, upperLimit: null, reason: "stop" }],
+          },
+        },
+      ],
+    }
+
+    const out = transformNetworkMap(networkMap, rules, { data: [] })
+
+    expect(out.rules[0].ruleBands).toHaveLength(2)
+    expect(out.rules[0].ruleBands[1].subRuleRef).toBe(".exit")
+  })
+
+  it("hydrates typologies with description and workflow thresholds", () => {
+    const networkMap = {
+      data: [{ messages: [{ typologies: [{ cfg: "999@1.0.0", rules: [] }] }] }],
+    }
+    const typologies = {
+      data: [{ cfg: "999@1.0.0", desc: "Typo 999", workflow: { interdictionThreshold: 250, alertThreshold: 100 } }],
+    }
+
+    const out = transformNetworkMap(networkMap, { data: [] }, typologies)
+
+    expect(out.typologies[0].typoDescription).toBe("Typo 999")
+    expect(out.typologies[0].workflow).toEqual({ interdictionThreshold: 250, alertThreshold: 100 })
+  })
+
+  it("defaults workflow thresholds to null when missing", () => {
+    const networkMap = {
+      data: [{ messages: [{ typologies: [{ cfg: "999@1.0.0", rules: [] }] }] }],
+    }
+    const typologies = { data: [{ cfg: "999@1.0.0", desc: "No thresholds", workflow: {} }] }
+
+    const out = transformNetworkMap(networkMap, { data: [] }, typologies)
+
+    expect(out.typologies[0].workflow).toEqual({ interdictionThreshold: null, alertThreshold: null })
+  })
+
+  it("builds the rule-to-linked-typologies display map", () => {
+    const networkMap = {
+      data: [
+        {
+          messages: [
+            {
+              typologies: [
+                { cfg: "999@1.0.0", rules: [{ id: "901@1.0.0" }, { id: "902@1.0.0" }] },
+                { cfg: "998@1.0.0", rules: [{ id: "901@1.0.0" }] },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    const out = transformNetworkMap(networkMap, { data: [] }, { data: [] })
+
+    const rule901 = out.rules.find((r) => r.title === "901")
+    const rule902 = out.rules.find((r) => r.title === "902")
+    expect(rule901?.displayLinkedTypo.sort()).toEqual(["998", "999"])
+    expect(rule902?.displayLinkedTypo).toEqual(["999"])
+  })
+
+  it("sorts rules and typologies alphabetically by title (with EFRuP moved to end)", () => {
+    const networkMap = {
+      data: [
+        {
+          messages: [
+            {
+              typologies: [
+                { cfg: "997@1.0.0", rules: [{ id: "903@1.0.0" }] },
+                { cfg: "999@1.0.0", rules: [{ id: "901@1.0.0" }] },
+                { cfg: "998@1.0.0", rules: [{ id: "EFRuP@1.0.0" }, { id: "902@1.0.0" }] },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    const out = transformNetworkMap(networkMap, { data: [] }, { data: [] })
+
+    expect(out.typologies.map((t) => t.title)).toEqual(["997", "998", "999"])
+    expect(out.rules.map((r) => r.title)).toEqual(["901", "902", "903", "EFRuP"])
+  })
+})

--- a/app/api/network-map/route.ts
+++ b/app/api/network-map/route.ts
@@ -7,6 +7,10 @@ import { adminGet, TazamaClientError } from "lib/tazama-client"
 
 const AUTHENTICATED = process.env.AUTHENTICATED === "true"
 
+type NetworkMapResponse = NonNullable<Parameters<typeof transformNetworkMap>[0]>
+type RuleResponse = NonNullable<Parameters<typeof transformNetworkMap>[1]>
+type TypologyResponse = NonNullable<Parameters<typeof transformNetworkMap>[2]>
+
 export async function GET() {
   let jwt: string | undefined
 
@@ -24,12 +28,12 @@ export async function GET() {
     // the BFF directly against Postgres; v4 must rebuild it from three
     // admin-service calls. See issue #116.
     const [networkMapResponse, ruleResponse, typologyResponse] = await Promise.all([
-      adminGet("/v1/admin/configuration/network_map?filters[active]=true", jwt),
-      adminGet("/v1/admin/configuration/rule", jwt),
-      adminGet("/v1/admin/configuration/typology", jwt),
+      adminGet<NetworkMapResponse>("/v1/admin/configuration/network_map?filters[active]=true", jwt),
+      adminGet<RuleResponse>("/v1/admin/configuration/rule", jwt),
+      adminGet<TypologyResponse>("/v1/admin/configuration/typology", jwt),
     ])
 
-    const transformed = transformNetworkMap(networkMapResponse as any, ruleResponse as any, typologyResponse as any)
+    const transformed = transformNetworkMap(networkMapResponse, ruleResponse, typologyResponse)
     return NextResponse.json(transformed)
   } catch (err) {
     if (err instanceof TazamaClientError) {

--- a/app/api/network-map/route.ts
+++ b/app/api/network-map/route.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NextResponse } from "next/server"
-import { auth } from "lib/auth"
-import { adminGet, TazamaClientError } from "lib/tazama-client"
 import type { Session } from "next-auth"
+import { auth } from "lib/auth"
+import { transformNetworkMap } from "lib/network-map-transform"
+import { adminGet, TazamaClientError } from "lib/tazama-client"
 
 const AUTHENTICATED = process.env.AUTHENTICATED === "true"
 
@@ -18,8 +19,18 @@ export async function GET() {
   }
 
   try {
-    const data = await adminGet("/v1/admin/configuration/network_map?filters[active]=true", jwt)
-    return NextResponse.json(data)
+    // The UI store consumer (`createUIFromNetworkMap`) expects a flat, hydrated
+    // shape `{ rules, typologies, typologiesEFRuP }`. v3 produced that shape in
+    // the BFF directly against Postgres; v4 must rebuild it from three
+    // admin-service calls. See issue #116.
+    const [networkMapResponse, ruleResponse, typologyResponse] = await Promise.all([
+      adminGet("/v1/admin/configuration/network_map?filters[active]=true", jwt),
+      adminGet("/v1/admin/configuration/rule", jwt),
+      adminGet("/v1/admin/configuration/typology", jwt),
+    ])
+
+    const transformed = transformNetworkMap(networkMapResponse as any, ruleResponse as any, typologyResponse as any)
+    return NextResponse.json(transformed)
   } catch (err) {
     if (err instanceof TazamaClientError) {
       return NextResponse.json({ error: err.message }, { status: err.status })

--- a/lib/network-map-transform.ts
+++ b/lib/network-map-transform.ts
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { Rule, RuleBand, TypoEFRuP, Typology } from "store/processors/processor.interface"
+
+/**
+ * Walks the active network map and the rule / typology configuration lists from
+ * admin-service and produces the flat, hydrated shape the UI store consumer
+ * (`createUIFromNetworkMap` in `store/processors/processor.provider.tsx`) reads.
+ *
+ * This is a direct port of the v3 BFF transformation that previously lived in
+ * `utils/networkMapDb.ts` against a Postgres pool. The shape contract is
+ * preserved exactly so the unchanged consumer keeps working.
+ *
+ * Inputs (each is the raw `adminGet` response from admin-service):
+ *   networkMapResponse: { data: NetworkMapConfig[], meta }
+ *   ruleResponse:       { data: RuleConfig[],       meta }
+ *   typologyResponse:   { data: TypologyConfig[],   meta }
+ *
+ * Output: { rules, typologies, typologiesEFRuP } - the v3 contract.
+ *
+ * If no active network map exists, returns empty arrays for all three.
+ */
+
+interface NetworkMapRuleRef {
+  id: string | number
+}
+
+interface NetworkMapTypology {
+  cfg: string
+  rules?: NetworkMapRuleRef[]
+}
+
+interface NetworkMapMessage {
+  typologies?: NetworkMapTypology[]
+}
+
+interface NetworkMapConfig {
+  messages?: NetworkMapMessage[]
+}
+
+interface AdminListEnvelope<T> {
+  data?: T[]
+}
+
+interface RuleConfigDoc {
+  id?: string
+  rule?: string
+  desc?: string
+  config?: {
+    bands?: RuleBand[]
+    cases?: RuleBand[]
+    exitConditions?: RuleBand[]
+  }
+}
+
+interface TypologyConfigDoc {
+  cfg?: string
+  desc?: string
+  workflow?: {
+    interdictionThreshold?: number | null
+    alertThreshold?: number | null
+  }
+}
+
+export interface TransformedNetworkMap {
+  rules: Rule[]
+  typologies: Typology[]
+  typologiesEFRuP: TypoEFRuP[]
+}
+
+const EFRUP_RULE_ID = "EFRuP@1.0.0"
+const EFRUP_TITLE = "EFRuP"
+const EFRUP_DESCRIPTION = "Event Flow Rule Processor"
+
+export function transformNetworkMap(
+  networkMapResponse: AdminListEnvelope<NetworkMapConfig> | null | undefined,
+  ruleResponse: AdminListEnvelope<RuleConfigDoc> | null | undefined,
+  typologyResponse: AdminListEnvelope<TypologyConfigDoc> | null | undefined
+): TransformedNetworkMap {
+  const networkMaps = networkMapResponse?.data ?? []
+  const ruleDocs = ruleResponse?.data ?? []
+  const typologyDocs = typologyResponse?.data ?? []
+
+  const typologiesRes: Typology[] = []
+  const rulesRes: Rule[] = []
+  const typologiesEFRuP: TypoEFRuP[] = []
+
+  const activeConfig = networkMaps[0]
+  if (activeConfig?.messages) {
+    for (const message of activeConfig.messages) {
+      if (!message.typologies) continue
+      for (const typology of message.typologies) {
+        const typologyTitle = typology.cfg.split("@")[0] ?? typology.cfg
+        const newTypology: Typology = {
+          // v3 assigned the cfg string here via `any`; the interface declares `number` but
+          // the runtime value is the full "<id>@<version>" string. Preserve that quirk.
+          id: typology.cfg as unknown as number,
+          title: typologyTitle,
+          color: "n",
+          result: null,
+          typoDescription: "",
+          workflow: { interdictionThreshold: null, alertThreshold: null },
+          linkedRules: [],
+        }
+
+        if (typology.rules) {
+          for (const rule of typology.rules) {
+            const ruleIdRaw = rule.id.toString()
+            const ruleIdStr = ruleIdRaw.split("@")[0] ?? ruleIdRaw
+            const newRule: Rule = {
+              id: parseFloat(ruleIdStr),
+              title: ruleIdStr,
+              rule: ruleIdRaw,
+              ruleDescription: "",
+              color: "n",
+              result: null,
+              wght: 0,
+              linkedTypologies: [],
+              ruleBands: [],
+              displayLinkedTypo: [],
+            }
+
+            if (ruleIdRaw === EFRUP_RULE_ID) {
+              typologiesEFRuP.push({ typology: typologyTitle, efrupResult: undefined })
+              const alreadyHaveEfrup = rulesRes.some((r) => r.title === EFRUP_TITLE)
+              if (!alreadyHaveEfrup) rulesRes.push(newRule)
+            } else {
+              rulesRes.push(newRule)
+            }
+
+            newTypology.linkedRules.push(newRule.title)
+          }
+        }
+
+        typologiesRes.push(newTypology)
+      }
+    }
+  }
+
+  // De-duplicate rules by numeric id (preserves first occurrence).
+  const finalRules: Rule[] = []
+  for (const rule of rulesRes) {
+    if (!finalRules.some((r) => r.id === rule.id)) finalRules.push(rule)
+  }
+
+  // Hydrate rules with description and band/case/exitCondition data.
+  for (const rule of finalRules) {
+    if (rule.title === EFRUP_TITLE) {
+      // v3 reassigned id to the cfg string and forced the description.
+      rule.id = EFRUP_RULE_ID as unknown as number
+      rule.title = EFRUP_TITLE
+      rule.ruleDescription = EFRUP_DESCRIPTION
+      continue
+    }
+
+    const ruleDoc = ruleDocs.find((r) => r.id === rule.rule)
+    if (!ruleDoc) continue
+
+    rule.ruleDescription = ruleDoc.desc ?? ""
+
+    const cfg = ruleDoc.config
+    if (!cfg) continue
+
+    const sourceBands = cfg.bands ?? cfg.cases ?? []
+    for (const band of sourceBands) {
+      rule.ruleBands.push({
+        subRuleRef: band.subRuleRef,
+        lowerLimit: band.lowerLimit ?? null,
+        upperLimit: band.upperLimit ?? null,
+        reason: band.reason,
+      })
+    }
+
+    if (cfg.exitConditions) {
+      for (const cond of cfg.exitConditions) {
+        rule.ruleBands.push({
+          subRuleRef: cond.subRuleRef,
+          lowerLimit: cond.lowerLimit ?? null,
+          upperLimit: cond.upperLimit ?? null,
+          reason: cond.reason,
+        })
+      }
+    }
+  }
+
+  // Hydrate typologies with description and workflow thresholds.
+  for (const typology of typologiesRes) {
+    const typoDoc = typologyDocs.find((t) => t.cfg === (typology.id as unknown as string))
+    if (!typoDoc) continue
+
+    typology.typoDescription = typoDoc.desc ?? ""
+    const wf = typoDoc.workflow ?? {}
+    typology.workflow.interdictionThreshold =
+      wf.interdictionThreshold !== undefined ? (wf.interdictionThreshold ?? null) : null
+    typology.workflow.alertThreshold = wf.alertThreshold !== undefined ? (wf.alertThreshold ?? null) : null
+  }
+
+  // Sort alphabetically by title.
+  finalRules.sort((a, b) => a.title.localeCompare(b.title))
+  typologiesRes.sort((a, b) => a.title.localeCompare(b.title))
+
+  // Move EFRuP to the end of the rule list (v3 behaviour).
+  const efrupIdx = finalRules.findIndex((r) => r.title === EFRUP_TITLE)
+  if (efrupIdx !== -1) {
+    const efrup = finalRules[efrupIdx]!
+    finalRules.splice(efrupIdx, 1)
+    finalRules.push(efrup)
+  }
+
+  // Build the rule -> linked typologies display map.
+  const ruleLinks = new Map<string, string[]>()
+  for (const typo of typologiesRes) {
+    for (const linkedRule of typo.linkedRules) {
+      const existing = ruleLinks.get(linkedRule)
+      if (existing) existing.push(typo.title)
+      else ruleLinks.set(linkedRule, [typo.title])
+    }
+  }
+  for (const rule of finalRules) {
+    const links = ruleLinks.get(rule.title)
+    if (links) rule.displayLinkedTypo = [...links]
+  }
+
+  return {
+    rules: finalRules,
+    typologies: typologiesRes,
+    typologiesEFRuP,
+  }
+}

--- a/lib/network-map-transform.ts
+++ b/lib/network-map-transform.ts
@@ -144,7 +144,7 @@ export function transformNetworkMap(
 
   // Hydrate rules with description and band/case/exitCondition data.
   for (const rule of finalRules) {
-    if (rule.title === EFRUP_TITLE) {
+    if (rule.rule === EFRUP_RULE_ID) {
       // v3 reassigned id to the cfg string and forced the description.
       rule.id = EFRUP_RULE_ID as unknown as number
       rule.title = EFRUP_TITLE
@@ -160,7 +160,7 @@ export function transformNetworkMap(
     const cfg = ruleDoc.config
     if (!cfg) continue
 
-    const sourceBands = cfg.bands ?? cfg.cases ?? []
+    const sourceBands = (cfg.bands?.length ? cfg.bands : cfg.cases) ?? []
     for (const band of sourceBands) {
       rule.ruleBands.push({
         subRuleRef: band.subRuleRef,
@@ -189,9 +189,8 @@ export function transformNetworkMap(
 
     typology.typoDescription = typoDoc.desc ?? ""
     const wf = typoDoc.workflow ?? {}
-    typology.workflow.interdictionThreshold =
-      wf.interdictionThreshold !== undefined ? (wf.interdictionThreshold ?? null) : null
-    typology.workflow.alertThreshold = wf.alertThreshold !== undefined ? (wf.alertThreshold ?? null) : null
+    typology.workflow.interdictionThreshold = wf.interdictionThreshold ?? null
+    typology.workflow.alertThreshold = wf.alertThreshold ?? null
   }
 
   // Sort alphabetically by title.
@@ -199,7 +198,7 @@ export function transformNetworkMap(
   typologiesRes.sort((a, b) => a.title.localeCompare(b.title))
 
   // Move EFRuP to the end of the rule list (v3 behaviour).
-  const efrupIdx = finalRules.findIndex((r) => r.title === EFRUP_TITLE)
+  const efrupIdx = finalRules.findIndex((r) => (r.id as unknown as string) === EFRUP_RULE_ID)
   if (efrupIdx !== -1) {
     const efrup = finalRules[efrupIdx]!
     finalRules.splice(efrupIdx, 1)


### PR DESCRIPTION
## Summary

Closes #116.

Restores the v3 BFF contract for `/api/network-map`. The v3 route returned a flat, hydrated `{ rules, typologies, typologiesEFRuP }` shape produced by a ~150-line walk-and-hydrate over a Postgres query. When the route was rewritten in v4 to call admin-service, the transformation was dropped and the BFF just forwarded the raw `{ data, meta }` envelope. The UI store consumer `createUIFromNetworkMap()` was left untouched and still reads top-level `rules` / `typologies` / `typologiesEFRuP` - none of which exist on the raw envelope, so all three dispatches were silently skipped and the rules / typologies panels never populated.

This was missed by the feature parity audit because row 6.6 was classified `OK (re-architected)` purely on the basis that the route forwarded to admin-service via `adminGet`. The audit did not diff the response shape against the unchanged consumer. Methodology gap and corrective procedure recorded in §9 of `tazama-demo-feature-parity-audit.md`.

## Changes

- **New: `lib/network-map-transform.ts`** - pure transformation function that:
  - Walks `messages[].typologies[].rules[]` and builds flat `Rule[]` / `Typology[]` / `TypoEFRuP[]` arrays.
  - De-duplicates the `EFRuP@1.0.0` rule (one entry only, pushed to the end of the rules list).
  - Pushes one entry to `typologiesEFRuP` per typology that references EFRuP.
  - Hydrates each rule with description and `ruleBands` from any of `config.bands` / `config.cases` / `config.exitConditions`.
  - Hydrates each typology with description and workflow thresholds (defaults missing values to `null`).
  - Sorts rules and typologies alphabetically by title; forces EFRuP to the end of the rule list.
  - Builds the rule-to-linked-typologies display map.
- **Modified: `app/api/network-map/route.ts`** - fetches network_map, rule, and typology lists from admin-service in parallel (`Promise.all`) and passes them through the transformer. Error mapping unchanged (TazamaClientError → mirror status, TimeoutError → 504, other → 502).
- **Modified: `__tests__/bff-network-map.test.ts`** - asserts the transformed shape, parallel fetches across all three admin endpoints, and the empty-input case.
- **New: `__tests__/network-map-transform.test.ts`** - 12 unit tests covering empty inputs, the EFRuP de-duplication and end-of-list ordering, all three rule-config shapes (`bands`, `cases`, `bands + exitConditions`), threshold defaulting, the display-link map, and alphabetical sort with EFRuP moved last.

## Verification

- `npm test` - 392 tests pass across 25 suites (24 pre-existing + 1 new).
- `npm run lint` - no new warnings on the changed files (lint-clean).
- `npm run build` - succeeds.
- Husky pre-push hook re-ran the full test suite and passed.

## Out of scope

- The `/api/conditions/*` 502s seen in the HAR. Those are caused by admin-service failing on `/v1/admin/event-flow-control/entity` and belong in a separate issue against the deployment.
- The unused `createRules()` / `createTypologies()` functions in `processor.provider.tsx` that call `/api/rules` and `/api/typologies` directly. They are dead but harmless; a cleanup PR is recommended after this lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The network map endpoint now returns enriched and structured configuration data including rules, typologies, and specialized rule categories.
  * Rules and typologies are populated with descriptions, metadata, and workflow thresholds for improved clarity.
  * Output is automatically sorted and formatted for optimal presentation in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->