### PR TITLE
fix(middleware): exclude public-folder static assets from auth gate

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,10 @@
+# Test-only environment overrides. Loaded by next/jest (via @next/env) for
+# every test run, taking precedence over .env. Keeps the test suite self-
+# contained so developers do not have to remember to override env vars in
+# their shell before `npm test` or before `git push` (the pre-push hook runs
+# the full suite).
+#
+# Tests that specifically exercise the AUTHENTICATED=true code path (e.g.
+# bff-*-auth.test.ts) set this back to "true" at the top of the file before
+# importing the route under test.
+AUTHENTICATED=false

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -122,3 +122,68 @@ describe("middleware - AUTHENTICATED=true", () => {
     })
   })
 })
+
+// ─── config.matcher (executed by the Next runtime, not the handler) ──────────
+//
+// Next.js compiles `config.matcher` patterns to regexes at build time and
+// decides BEFORE invoking middleware which requests it gates. The handler
+// tests above cannot exercise this layer, so the only way to assert on
+// matcher behaviour from a unit test is to compile the pattern string into
+// a RegExp ourselves and probe it directly. The pattern in `middleware.ts`
+// is a valid JS regex literal, so `new RegExp(...)` is a faithful enough
+// approximation of what the Next runtime does for these assertions.
+
+function loadMatcher(): RegExp {
+  let config: { matcher: string[] } | undefined
+  jest.isolateModules(() => {
+    config = (require("middleware") as { config: { matcher: string[] } }).config
+  })
+  if (!config) throw new Error("failed to load middleware config")
+  return new RegExp("^" + config.matcher[0] + "$")
+}
+
+describe("middleware - config.matcher", () => {
+  const matcher = loadMatcher()
+
+  describe("matches application paths (so middleware runs)", () => {
+    it.each([["/"], ["/login"], ["/dashboard"], ["/reports/xyz"], ["/login/forgot-password"]])("matches %s", (path) => {
+      expect(matcher.test(path)).toBe(true)
+    })
+  })
+
+  describe("excludes Next.js internals (so middleware is bypassed)", () => {
+    it.each([
+      ["/api/version"],
+      ["/api/auth/callback/credentials"],
+      ["/_next/static/chunks/main.js"],
+      ["/_next/image"],
+      ["/favicon.ico"],
+    ])("excludes %s", (path) => {
+      expect(matcher.test(path)).toBe(false)
+    })
+  })
+
+  describe("excludes public-folder static assets (so the image optimizer's internal fetch is not redirected)", () => {
+    // These are the literal string paths emitted by components that
+    // reference public/ assets directly (e.g. StatusIndicator's light icons,
+    // logo files, favicons, fonts). If any of these were matched by the
+    // middleware, the optimizer's server-side fetch back to the public URL
+    // would carry no session cookie, be redirected to /login, and return
+    // HTML instead of bytes - logged as "received null".
+    it.each([
+      ["/neutral-light-1.png"],
+      ["/green-light-1.png"],
+      ["/red-light-1.png"],
+      ["/yellow-light-1.png"],
+      ["/blue-light-1.png"],
+      ["/tazamaLogo.svg"],
+      ["/treeImage.png"],
+      ["/Tazama_logo_400x400.jpg"],
+      ["/some/nested/asset.webp"],
+      ["/fonts/inter.woff2"],
+      ["/styles/site.css"],
+    ])("excludes %s", (path) => {
+      expect(matcher.test(path)).toBe(false)
+    })
+  })
+})

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -182,6 +182,17 @@ describe("middleware - config.matcher", () => {
       ["/some/nested/asset.webp"],
       ["/fonts/inter.woff2"],
       ["/styles/site.css"],
+      // One case per remaining suffix token in the matcher regex, so the
+      // matrix exercises every excluded extension and catches regex drift.
+      ["/image.jpeg"],
+      ["/anim.gif"],
+      ["/touch-icon.ico"],
+      ["/bundle.js"],
+      ["/bundle.js.map"],
+      ["/fonts/inter.woff"],
+      ["/fonts/inter.ttf"],
+      ["/fonts/inter.eot"],
+      ["/fonts/inter.otf"],
     ])("excludes %s", (path) => {
       expect(matcher.test(path)).toBe(false)
     })

--- a/__tests__/nats-helpers.test.ts
+++ b/__tests__/nats-helpers.test.ts
@@ -1,22 +1,35 @@
 // SPDX-License-Identifier: Apache-2.0
-import { filterByTenantId, computeTerminalSubject } from "lib/nats-helpers"
+import { computeTerminalSubject, filterByTenantId } from "lib/nats-helpers"
 
 // ---------------------------------------------------------------------------
 // filterByTenantId
 // ---------------------------------------------------------------------------
 describe("filterByTenantId", () => {
-  it("returns true when message.TenantId matches tenantId", () => {
-    const msg = { TenantId: "org-xyz", transaction: {} }
+  it("returns true when message.transaction.TenantId matches tenantId", () => {
+    const msg = { transaction: { TenantId: "org-xyz" } }
     expect(filterByTenantId(msg, "org-xyz")).toBe(true)
   })
 
-  it("returns false when message.TenantId does not match tenantId", () => {
-    const msg = { TenantId: "org-abc", transaction: {} }
+  it("returns false when message.transaction.TenantId does not match tenantId", () => {
+    const msg = { transaction: { TenantId: "org-abc" } }
     expect(filterByTenantId(msg, "org-xyz")).toBe(false)
   })
 
-  it("returns false when TenantId field is missing from message", () => {
+  it("returns false when transaction.TenantId field is missing from message", () => {
     const msg = { transaction: {} }
+    expect(filterByTenantId(msg, "org-xyz")).toBe(false)
+  })
+
+  it("returns false when transaction block itself is missing", () => {
+    const msg = { report: {} }
+    expect(filterByTenantId(msg, "org-xyz")).toBe(false)
+  })
+
+  it("ignores a top-level TenantId outside the transaction block", () => {
+    // Regression guard: an earlier implementation read `msg.TenantId`, which
+    // silently dropped every real event-adjudicator message (the shape places
+    // TenantId inside `transaction`).
+    const msg = { TenantId: "org-xyz", transaction: {} }
     expect(filterByTenantId(msg, "org-xyz")).toBe(false)
   })
 
@@ -34,38 +47,24 @@ describe("filterByTenantId", () => {
 // ---------------------------------------------------------------------------
 describe("computeTerminalSubject", () => {
   it("appends tenantId suffix when destination is 'tenant'", () => {
-    expect(computeTerminalSubject("investigation-service", "tenant", "org-xyz")).toBe(
-      "investigation-service-org-xyz"
-    )
+    expect(computeTerminalSubject("investigation-service", "tenant", "org-xyz")).toBe("investigation-service-org-xyz")
   })
 
   it("returns bare producer when destination is 'global'", () => {
-    expect(computeTerminalSubject("investigation-service", "global", "org-xyz")).toBe(
-      "investigation-service"
-    )
+    expect(computeTerminalSubject("investigation-service", "global", "org-xyz")).toBe("investigation-service")
   })
 
   it("returns bare producer when destination is any value other than 'tenant'", () => {
-    expect(computeTerminalSubject("interdiction-service-tp", "custom", "org-xyz")).toBe(
-      "interdiction-service-tp"
-    )
+    expect(computeTerminalSubject("interdiction-service-tp", "custom", "org-xyz")).toBe("interdiction-service-tp")
   })
 
   it("returns bare producer when destination is empty string", () => {
-    expect(computeTerminalSubject("interdiction-service-ef", "", "org-xyz")).toBe(
-      "interdiction-service-ef"
-    )
+    expect(computeTerminalSubject("interdiction-service-ef", "", "org-xyz")).toBe("interdiction-service-ef")
   })
 
   it("handles all three producer types correctly for 'tenant' destination", () => {
-    expect(computeTerminalSubject("investigation-service", "tenant", "acme")).toBe(
-      "investigation-service-acme"
-    )
-    expect(computeTerminalSubject("interdiction-service-tp", "tenant", "acme")).toBe(
-      "interdiction-service-tp-acme"
-    )
-    expect(computeTerminalSubject("interdiction-service-ef", "tenant", "acme")).toBe(
-      "interdiction-service-ef-acme"
-    )
+    expect(computeTerminalSubject("investigation-service", "tenant", "acme")).toBe("investigation-service-acme")
+    expect(computeTerminalSubject("interdiction-service-tp", "tenant", "acme")).toBe("interdiction-service-tp-acme")
+    expect(computeTerminalSubject("interdiction-service-ef", "tenant", "acme")).toBe("interdiction-service-ef-acme")
   })
 })

--- a/__tests__/processor.reducer.test.ts
+++ b/__tests__/processor.reducer.test.ts
@@ -134,18 +134,16 @@ describe("UPDATE_TYPO", () => {
     expect(next.typologyLoading).toBe(true)
   })
 
-  it("SUCCESS clears flag and stores typology (singular) payload", () => {
-    // Note: UPDATE_TYPO_SUCCESS stores to `typology` (singular), not `typologies`
+  it("SUCCESS clears flag and stores updated typologies array payload", () => {
     const next = ProcessorReducer(baseState, { type: ACTIONS.UPDATE_TYPO_SUCCESS, payload: TYPO_SINGLE_PAYLOAD })
     expect(next.typologyLoading).toBe(false)
-    expect(next.typology).toEqual(TYPO_SINGLE_PAYLOAD)
-    expect(next.typologies).toBe(baseState.typologies) // list unchanged
+    expect(next.typologies).toEqual(TYPO_SINGLE_PAYLOAD)
   })
 
-  it("FAIL clears flag and empties typology (singular) to []", () => {
+  it("FAIL clears flag and empties typologies array", () => {
     const next = ProcessorReducer(baseState, { type: ACTIONS.UPDATE_TYPO_FAIL })
     expect(next.typologyLoading).toBe(false)
-    expect(next.typology).toEqual([])
+    expect(next.typologies).toEqual([])
   })
 })
 

--- a/__tests__/processor.reducer.test.ts
+++ b/__tests__/processor.reducer.test.ts
@@ -135,9 +135,11 @@ describe("UPDATE_TYPO", () => {
   })
 
   it("SUCCESS clears flag and stores updated typologies array payload", () => {
-    const next = ProcessorReducer(baseState, { type: ACTIONS.UPDATE_TYPO_SUCCESS, payload: TYPO_SINGLE_PAYLOAD })
+    // Reducer contract: typologies is always an array. Wrap the single-object
+    // fixture so this regression test actually exercises the array shape.
+    const next = ProcessorReducer(baseState, { type: ACTIONS.UPDATE_TYPO_SUCCESS, payload: [TYPO_SINGLE_PAYLOAD] })
     expect(next.typologyLoading).toBe(false)
-    expect(next.typologies).toEqual(TYPO_SINGLE_PAYLOAD)
+    expect(next.typologies).toEqual([TYPO_SINGLE_PAYLOAD])
   })
 
   it("FAIL clears flag and empties typologies array", () => {

--- a/app/(demo)/layout.tsx
+++ b/app/(demo)/layout.tsx
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
+import { extractTenant } from "@tazama-lf/auth-lib"
 import Link from "next/link"
+import type { Session } from "next-auth"
+import { ClearAllButton } from "components/Header/ClearAllButton"
+import { HeaderUserInfo } from "components/Header/HeaderUserInfo"
+import { auth } from "lib/auth"
 import EntityProvider from "store/entities/entity.provider"
 import ProcessorProvider from "store/processors/processor.provider"
-import { auth } from "lib/auth"
-import { extractTenant } from "@tazama-lf/auth-lib"
-import { HeaderUserInfo } from "components/Header/HeaderUserInfo"
-import type { Session } from "next-auth"
 
 const AUTHENTICATED = process.env.AUTHENTICATED === "true"
 
@@ -80,8 +81,12 @@ export default async function DemoLayout({ children }: { children: React.ReactNo
             </svg>
           </Link>
 
-          {AUTHENTICATED && displayName && tenantId && (
-            <HeaderUserInfo displayName={displayName} tenantId={tenantId} />
+          {AUTHENTICATED && displayName && tenantId ? (
+            <HeaderUserInfo displayName={displayName} tenantId={tenantId}>
+              <ClearAllButton />
+            </HeaderUserInfo>
+          ) : (
+            <ClearAllButton />
           )}
         </div>
         {children}

--- a/app/(demo)/page.tsx
+++ b/app/(demo)/page.tsx
@@ -285,6 +285,28 @@ const Web = () => {
     }
   }, [])
 
+  // Subscribe to the header Clear All button. Skip the initial mount fire
+  // (clearAllSignal starts at 0) so a fresh page load does not gratuitously
+  // clear state. On each subsequent bump from triggerClearAll(), flush all
+  // page-local selection / hover state alongside the four context-side
+  // clears that the button itself does not have direct access to.
+  useEffect(() => {
+    if (processCtx.clearAllSignal === 0) return
+    setSelectedRule(null)
+    setSelectedRules([])
+    setSelectedType(null)
+    setSelectedTypes([])
+    setHoverRules([])
+    setHoveredRule(null)
+    setHoverTypes([])
+    setHoveredType(null)
+    processCtx.clearLinkedTypologies()
+    entityCtx.clearUIData()
+    processCtx.resetAllLights()
+    processCtx.clearResults()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [processCtx.clearAllSignal])
+
   if (loading) return <Loader />
   if (error) return <p>Error: {error}</p>
 
@@ -376,27 +398,6 @@ const Web = () => {
   return (
     <div className="flex min-h-full w-full flex-col">
       <ConnectionStatusBanner status={connectionStatus} />
-      <div className="z-99 absolute right-[100px] top-5 cursor-pointer">
-        <button
-          className="content-right-center ml-auto rounded-md bg-gradient-to-b from-gray-100 to-gray-200 p-2 shadow-lg"
-          onClick={() => {
-            setSelectedRule(null)
-            setSelectedRules([])
-            setSelectedType(null)
-            setSelectedTypes([])
-            setHoverRules([])
-            setHoveredRule(null)
-            setHoverTypes([])
-            setHoveredType(null)
-            processCtx.clearLinkedTypologies()
-            entityCtx.clearUIData()
-            processCtx.resetAllLights()
-            processCtx.clearResults()
-          }}
-        >
-          Clear All
-        </button>
-      </div>
       <div className="bg-slate-300/25 px-3 pb-1 pt-4">
         <div className="grid grid-cols-12 gap-5">
           {/* Debtors */}

--- a/app/(demo)/page.tsx
+++ b/app/(demo)/page.tsx
@@ -182,39 +182,50 @@ const Web = () => {
   const [selectedCreditorEntity, setSelectedCreditorEntity] = useState<number>(0)
 
   useEffect(() => {
-    const socketInitializer = async () => {
+    // Capture the socket in a closure-local so each effect run owns its own
+    // connection. The previous implementation assigned to a module-scope
+    // `socket` from an async initializer, which leaks in dev: React Strict
+    // Mode mounts the effect twice and Fast Refresh re-runs it on every save,
+    // but the `await fetch("/api/health")` suspends past the cleanup window.
+    // The cleanup then ran with `socket` still undefined (no-op), while every
+    // subsequent initializer overwrote the module var with a fresh `io()`,
+    // leaving 2-3 live socket connections per browser tab. Symptoms: every
+    // eventAdjudicator log line shows count >=2, and intermittent messages
+    // get lost when the server tears down a stale leaked connection just as a
+    // new one is being bound.
+    let aborted = false
+    let localSocket: ReturnType<typeof io> | undefined
+    ;(async () => {
       try {
         await fetch("/api/health")
-        socket = io()
-        socket.on("connect", () => {
+        if (aborted) return
+        localSocket = io()
+        socket = localSocket
+        localSocket.on("connect", () => {
           console.log("connected")
         })
-        socket.on("welcome", (msg) => {
+        localSocket.on("welcome", (msg) => {
           console.log("received", msg)
         })
-        socket.on("connection:status", (status: ConnectionStatus) => {
+        localSocket.on("connection:status", (status: ConnectionStatus) => {
           setConnectionStatus(status)
         })
-        socket.on("eventAdjudicator", async (msg) => {
+        localSocket.on("eventAdjudicator", async (msg) => {
           if (processCtx.activeMsgId && msg?.transaction?.FIToFIPmtSts?.GrpHdr?.MsgId !== processCtx.activeMsgId) return
           await processCtx.handleAdjudicatorLive(msg)
         })
       } catch (error) {
         console.log(error)
       }
-    }
-    socketInitializer()
-    // Cleanup so React Strict Mode re-mounts (dev) do not leak duplicate
-    // sockets and stacked listeners. socketInitializer is async and assigns
-    // the module-scoped `socket` after a network round-trip, so the cleanup
-    // checks for the assignment before tearing down.
+    })()
     return () => {
-      if (socket) {
-        socket.off("connect")
-        socket.off("welcome")
-        socket.off("connection:status")
-        socket.off("eventAdjudicator")
-        socket.disconnect()
+      aborted = true
+      if (localSocket) {
+        localSocket.off("connect")
+        localSocket.off("welcome")
+        localSocket.off("connection:status")
+        localSocket.off("eventAdjudicator")
+        localSocket.disconnect()
       }
     }
   }, [])

--- a/components/Header/ClearAllButton.tsx
+++ b/components/Header/ClearAllButton.tsx
@@ -1,0 +1,23 @@
+"use client"
+// SPDX-License-Identifier: Apache-2.0
+import { useContext } from "react"
+import ProcessorContext from "store/processors/processor.context"
+
+// Header-resident button that asks the ProcessorProvider to fan out a clear
+// signal. The page-level component subscribes to `clearAllSignal` to flush
+// its local selection / hover state at the same time as the context-side
+// clears (resetAllLights, clearResults, clearLinkedTypologies, clearUIData).
+// Lives in the header alongside Logout instead of being absolutely positioned
+// on top of HeaderUserInfo (which used to overlap the tenant text).
+export function ClearAllButton() {
+  const { triggerClearAll } = useContext(ProcessorContext)
+  return (
+    <button
+      type="button"
+      onClick={triggerClearAll}
+      className="rounded-md border border-gray-300 bg-gradient-to-b from-gray-100 to-gray-200 p-2 shadow-lg hover:from-gray-200 hover:to-gray-300 active:shadow-md"
+    >
+      Clear All
+    </button>
+  )
+}

--- a/components/Header/HeaderUserInfo.tsx
+++ b/components/Header/HeaderUserInfo.tsx
@@ -1,22 +1,30 @@
 "use client"
 // SPDX-License-Identifier: Apache-2.0
 import { signOut } from "next-auth/react"
+import type { ReactNode } from "react"
 
 interface HeaderUserInfoProps {
   displayName: string
   tenantId: string
+  // Optional slot rendered between the tenant text and the Logout button.
+  // Used to inline the header Clear All button so the three header items
+  // (name/tenant, Clear All, Logout) share one flex row with consistent
+  // spacing and Logout stays in the top-right corner.
+  children?: ReactNode
 }
 
-export function HeaderUserInfo({ displayName, tenantId }: HeaderUserInfoProps) {
+export function HeaderUserInfo({ displayName, tenantId, children }: HeaderUserInfoProps) {
   return (
-    <div className="flex items-center gap-4">
+    <div className="flex items-center gap-3">
       <div className="text-right text-sm text-gray-600">
         <div className="font-medium text-gray-800">{displayName}</div>
         <div className="text-xs text-gray-500">Tenant: {tenantId}</div>
       </div>
+      {children}
       <button
+        type="button"
         onClick={() => signOut({ callbackUrl: "/login" })}
-        className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+        className="rounded-md border border-gray-300 bg-gradient-to-b from-gray-100 to-gray-200 p-2 shadow-lg hover:from-gray-200 hover:to-gray-300 active:shadow-md"
       >
         Logout
       </button>

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -56,7 +56,13 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           accessToken = await response.text()
         }
         if (!accessToken) return null
-        return { id: credentials.username as string, accessToken }
+        // Capture the username as `name` so NextAuth auto-copies it into
+        // the JWT (jwt callback) and the session (session callback). The
+        // header's HeaderUserInfo then reads session.user.name to label
+        // the signed-in account; without this it would fall through to a
+        // literal "User" string. We do not have an email address - the
+        // auth-service returns only the JWT.
+        return { id: credentials.username as string, name: credentials.username as string, accessToken }
       },
     }),
   ],

--- a/lib/nats-helpers.ts
+++ b/lib/nats-helpers.ts
@@ -1,13 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Returns true when the decoded NATS message's TenantId matches the expected
- * tenantId. Returns false for any missing or mismatched value.
+ * Returns true when the decoded NATS message's transaction TenantId matches
+ * the expected tenantId. Returns false for any missing or mismatched value.
+ *
+ * The decoded payload follows the frms-coe-lib pacs.002/pacs.008 envelope,
+ * where the tenant id lives inside `transaction.TenantId` rather than at the
+ * top level. Reading from the top level (as an earlier version of this
+ * function did) silently dropped every message under AUTHENTICATED=true.
  */
 export function filterByTenantId(message: unknown, tenantId: string): boolean {
   if (message === null || typeof message !== "object") return false
-  const msg = message as Record<string, unknown>
-  return msg["TenantId"] === tenantId
+  const msg = message as { transaction?: { TenantId?: unknown } }
+  return msg.transaction?.TenantId === tenantId
 }
 
 /**

--- a/middleware.ts
+++ b/middleware.ts
@@ -43,12 +43,29 @@ export default AUTHENTICATED
 export const config = {
   matcher: [
     /*
-     * Match all request paths except for the ones starting with:
-     * - api (API routes - auth route handler must remain public)
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico
+     * Match all request paths except for:
+     *
+     * - api               (API routes - auth route handler must remain public)
+     * - _next/static      (build-emitted static chunks)
+     * - _next/image       (the image optimizer endpoint itself)
+     * - favicon.ico       (browser convention)
+     * - *.{png,jpg,...}   (public/-folder static assets - see note below)
+     *
+     * The trailing extension list is essential when AUTHENTICATED=true.
+     * Components that reference public-folder assets by string path (e.g.
+     * `<Image src="/neutral-light-1.png" />`) get rewritten to
+     * `/_next/image?url=%2Fneutral-light-1.png&...`. The browser request to
+     * that URL is excluded by `_next/image` above, but the optimizer then
+     * makes a SERVER-side internal fetch back to `/neutral-light-1.png` to
+     * read the source bytes - and that internal fetch carries no cookies.
+     * Without an extension exclusion it would hit this middleware, fail the
+     * auth check, get redirected to /login, and the optimizer would receive
+     * HTML instead of an image (logged as "received null").
+     *
+     * Public-folder assets are public by design, so excluding their paths
+     * from auth checks is the correct behaviour and the standard Next.js
+     * pattern.
      */
-    "/((?!api|_next/static|_next/image|favicon.ico).*)",
+    "/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:png|jpg|jpeg|svg|gif|webp|ico|css|js|map|woff2?|ttf|eot|otf)$).*)",
   ],
 }

--- a/server.js
+++ b/server.js
@@ -35,9 +35,13 @@ const NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET
 // ---------------------------------------------------------------------------
 // Inline filter helpers (mirrors lib/nats-helpers.ts)
 // ---------------------------------------------------------------------------
+// The decoded payload follows the frms-coe-lib pacs.002/pacs.008 envelope,
+// where the tenant id lives inside `transaction.TenantId` rather than at
+// the top level. Reading from the top level (as an earlier version did)
+// silently dropped every message under AUTHENTICATED=true.
 function filterByTenantId(message, tenantId) {
   if (message === null || typeof message !== "object") return false
-  return message["TenantId"] === tenantId
+  return message.transaction?.TenantId === tenantId
 }
 
 function computeTerminalSubject(producer, destination, tenantId) {

--- a/server.js
+++ b/server.js
@@ -205,7 +205,13 @@ function decodeMsg(data) {
  */
 function ensureGlobalSub(subject, room, io) {
   if (!nc || globalSubs.has(subject)) return
-  const sub = nc.subscribe(subject, { queue: "DEMO_MONITORING" })
+  // No queue group: the demo UI backend is one independent observer per
+  // process. A queue group would cause NATS to round-robin messages between
+  // any other consumer registered under the same queue (other dev box,
+  // stale process, deployed instance), silently breaking the live pipeline
+  // view. Each backend must receive every message and fan out to its own
+  // Socket.IO clients; tenant filtering happens at emit time.
+  const sub = nc.subscribe(subject)
   globalSubs.set(subject, sub)
   ;(async () => {
     for await (const msg of sub) {
@@ -246,7 +252,10 @@ function ensureTenantSub(producer, tenantId, room, io) {
     existing.refCount++
     return
   }
-  const sub = nc.subscribe(subject, { queue: "DEMO_MONITORING" })
+  // No queue group - see ensureGlobalSub for rationale. The tenant-scoped
+  // subject already isolates messages to this tenant; sharing them via a
+  // queue group would just steal them from other demo observers.
+  const sub = nc.subscribe(subject)
   tenantSubs.set(key, { sub, refCount: 1 })
   ;(async () => {
     for await (const msg of sub) {

--- a/store/processors/processor.context.tsx
+++ b/store/processors/processor.context.tsx
@@ -78,6 +78,14 @@ interface Context {
   setShowCreditorConditionsCreate: (option: boolean) => void
   setLinkedTypologies: (linkedTypos: LinkedTypo[]) => void
   clearLinkedTypologies: () => void
+  // Counter incremented every time the user clicks the header "Clear All"
+  // button. The page-level component (app/(demo)/page.tsx) subscribes via
+  // useEffect to flush its local selection / hover state alongside the
+  // context-side clears. This keeps the button decoupled from page.tsx so
+  // it can live in the layout header instead of being absolutely positioned
+  // on top of it.
+  clearAllSignal: number
+  triggerClearAll: () => void
 }
 
 const ProcessorContext = createContext<Context>({
@@ -138,6 +146,8 @@ const ProcessorContext = createContext<Context>({
   setShowCreditorConditionsCreate: (option: boolean) => {},
   setLinkedTypologies: (linkedTypos: LinkedTypo[]) => {},
   clearLinkedTypologies: () => {},
+  clearAllSignal: 0,
+  triggerClearAll: () => {},
 })
 
 export default ProcessorContext

--- a/store/processors/processor.provider.tsx
+++ b/store/processors/processor.provider.tsx
@@ -480,7 +480,6 @@ const ProcessorProvider = ({ children }: Props) => {
         updated.color = "y"
       } else if (msg.result >= interThreshold) {
         updated.color = "r"
-        ;(updated as any).stop = true
       }
     } else if (alertThreshold !== null && interThreshold === null) {
       if (msg.result < alertThreshold) {
@@ -493,6 +492,11 @@ const ProcessorProvider = ({ children }: Props) => {
         updated.color = "y"
       }
     }
+    // Keep `stop` synchronised with `color`. `updated` starts as a spread of
+    // the previous typology, so without this reset a prior interdiction
+    // (stop: true) would latch even after follow-up results drop below the
+    // interdiction threshold.
+    ;(updated as any).stop = updated.color === "r"
     next[idx] = updated
     return next
   }

--- a/store/processors/processor.provider.tsx
+++ b/store/processors/processor.provider.tsx
@@ -393,8 +393,9 @@ const ProcessorProvider = ({ children }: Props) => {
 
   const updateTypologies = async (msg: any) => {
     try {
+      const index: number = state.typologies.findIndex((r: Typology) => r.title === msg?.cfg?.split("@")?.[0])
+      if (index === -1) return
       dispatch({ type: ACTIONS.UPDATE_TYPO_LOADING })
-      const index: number = state.typologies.findIndex((r: Typology) => r.title === msg.cfg.split("@")[0])
 
       const updatedTypo: any[] = [...state.typologies]
 

--- a/store/processors/processor.provider.tsx
+++ b/store/processors/processor.provider.tsx
@@ -83,7 +83,6 @@ const ProcessorProvider = ({ children }: Props) => {
   const [wsAddress, setWsAddress] = useState<string>(process.env.NEXT_PUBLIC_WS_URL ?? "")
   const msgId: any = useRef("")
   const efrupIdRef = useRef<string | undefined>(undefined)
-  const currentMsgIdRef = useRef<string | null>(null)
 
   useEffect(() => {
     try {
@@ -145,10 +144,6 @@ const ProcessorProvider = ({ children }: Props) => {
   }, [state.tadProcResults])
 
   useEffect(() => {
-    currentMsgIdRef.current = entityCtx.currentMsgId ?? null
-  }, [entityCtx.currentMsgId])
-
-  useEffect(() => {
     const newSocket: any = io(wsAddress!, {
       reconnectionAttempts: 5,
       reconnectionDelay: 3000,
@@ -192,8 +187,18 @@ const ProcessorProvider = ({ children }: Props) => {
 
   useEffect(() => {
     adjudicatorHandlerRef.current = (msg: any) => {
-      const currentMsgId = currentMsgIdRef.current
-      if (msg?.transaction?.FIToFIPmtSts?.GrpHdr?.MsgId !== currentMsgId) return
+      const incomingMsgId = msg?.transaction?.FIToFIPmtSts?.GrpHdr?.MsgId
+      // Lenient MsgId filter, matching the G-socket in app/(demo)/page.tsx:
+      // only reject when we know the message belongs to a different
+      // transaction (currentMsgId is set AND mismatches). When currentMsgId
+      // is not yet set we MUST process the message - NATS routinely beats
+      // React's commit-then-flush-effects cycle for the first transaction
+      // after page load, so any strict equality check here drops the very
+      // first event-adjudicator message intermittently and the typology
+      // lights silently fail to paint. Reading entityCtx.currentMsgId
+      // directly keeps the filter as fresh as React allows.
+      const currentMsgId = entityCtx.currentMsgId
+      if (currentMsgId && incomingMsgId && incomingMsgId !== currentMsgId) return
       const tadpResult = msg?.report?.tadpResult
       if (!tadpResult || !Object.keys(tadpResult).includes("typologyResult")) return
       const typoResults: any[] = tadpResult.typologyResult ?? []
@@ -210,7 +215,6 @@ const ProcessorProvider = ({ children }: Props) => {
       if (nextTypologies !== state.typologies) {
         dispatch({ type: ACTIONS.UPDATE_TYPO_SUCCESS, payload: nextTypologies })
       }
-      const incomingMsgId = msg?.transaction?.FIToFIPmtSts?.GrpHdr?.MsgId
       if (msgId.current !== incomingMsgId) {
         msgId.current = incomingMsgId
       }

--- a/store/processors/processor.provider.tsx
+++ b/store/processors/processor.provider.tsx
@@ -184,30 +184,47 @@ const ProcessorProvider = ({ children }: Props) => {
     }
   }, [isConnected])
 
-  useEffect(() => {
-    if (socket !== undefined) {
-      socket.on("eventAdjudicator", (msg) => {
-        const currentMsgId = currentMsgIdRef.current
-        if (msg?.transaction?.FIToFIPmtSts?.GrpHdr?.MsgId === currentMsgId) {
-          const typoResult = Object.keys(msg.report.tadpResult).includes("typologyResult")
-          if (typoResult) {
-            msg.report.tadpResult.typologyResult.map((tpRes: any) => {
-              setTimeout(
-                async () => {
-                  await updateTypologies(tpRes)
-                },
-                Math.floor(Math.random() * (500 - 200)) + 200
-              )
+  // Keep an always-current reference to the eventAdjudicator handler so the
+  // listener registered against the socket can read the latest state without
+  // being re-registered on every state change. Re-registering created stale
+  // closures and accumulated listeners (each fired N times for the Nth message).
+  const adjudicatorHandlerRef = useRef<(msg: any) => void>(() => {})
 
-              if (msgId.current !== msg?.transaction?.FIToFIPmtSts?.GrpHdr?.MsgId) {
-                msgId.current = msg?.transaction?.FIToFIPmtSts?.GrpHdr?.MsgId
-              }
-            })
-          }
-        }
+  useEffect(() => {
+    adjudicatorHandlerRef.current = (msg: any) => {
+      const currentMsgId = currentMsgIdRef.current
+      if (msg?.transaction?.FIToFIPmtSts?.GrpHdr?.MsgId !== currentMsgId) return
+      const tadpResult = msg?.report?.tadpResult
+      if (!tadpResult || !Object.keys(tadpResult).includes("typologyResult")) return
+      const typoResults: any[] = tadpResult.typologyResult ?? []
+      // Build the next typologies array in one pass and dispatch once, so a
+      // burst of typology results does not race against React's render cycle
+      // (each updateTypologies dispatch would otherwise read the same stale
+      // state.typologies and clobber its predecessor).
+      let nextTypologies = state.typologies
+      typoResults.forEach((tpRes: any) => {
+        const idx: number = nextTypologies.findIndex((r: Typology) => r.title === tpRes?.cfg?.split("@")?.[0])
+        if (idx === -1) return
+        nextTypologies = applyTypologyUpdate(nextTypologies, idx, tpRes)
       })
+      if (nextTypologies !== state.typologies) {
+        dispatch({ type: ACTIONS.UPDATE_TYPO_SUCCESS, payload: nextTypologies })
+      }
+      const incomingMsgId = msg?.transaction?.FIToFIPmtSts?.GrpHdr?.MsgId
+      if (msgId.current !== incomingMsgId) {
+        msgId.current = incomingMsgId
+      }
     }
-  }, [state.typologies])
+  })
+
+  useEffect(() => {
+    if (!socket) return
+    const handler = (msg: any) => adjudicatorHandlerRef.current(msg)
+    socket.on("eventAdjudicator", handler)
+    return () => {
+      socket.off("eventAdjudicator", handler)
+    }
+  }, [socket])
 
   const handleLinkedTypologies = async (msg: any) => {
     const typoResults: Typology[] = msg.report.tadpResult.typologyResult
@@ -391,51 +408,49 @@ const ProcessorProvider = ({ children }: Props) => {
     }
   }
 
+  // Returns a new typologies array with index `idx` updated by `msg`.
+  // Pure helper so callers can chain multiple updates in a single dispatch.
+  const applyTypologyUpdate = (typologies: any[], idx: number, msg: any): any[] => {
+    const next = [...typologies]
+    const updated = { ...next[idx], result: msg.result, color: "g" } as Typology
+    let interThreshold: number | null = null
+    let alertThreshold: number | null = null
+    if (msg?.workflow && Object.keys(msg.workflow).includes("interdictionThreshold")) {
+      interThreshold = msg.workflow.interdictionThreshold
+    }
+    if (msg?.workflow && Object.keys(msg.workflow).includes("alertThreshold")) {
+      alertThreshold = msg.workflow.alertThreshold
+    }
+    if (alertThreshold !== null && interThreshold !== null) {
+      if (msg.result < alertThreshold) {
+        updated.color = "g"
+      } else if (msg.result >= alertThreshold && msg.result < interThreshold) {
+        updated.color = "y"
+      } else if (msg.result >= interThreshold) {
+        updated.color = "r"
+        ;(updated as any).stop = true
+      }
+    } else if (alertThreshold !== null && interThreshold === null) {
+      if (msg.result < alertThreshold) {
+        updated.color = "g"
+      } else if (msg.result >= alertThreshold) {
+        updated.color = "y"
+      }
+    } else {
+      if (msg.result < 0) {
+        updated.color = "y"
+      }
+    }
+    next[idx] = updated
+    return next
+  }
+
   const updateTypologies = async (msg: any) => {
     try {
       const index: number = state.typologies.findIndex((r: Typology) => r.title === msg?.cfg?.split("@")?.[0])
       if (index === -1) return
       dispatch({ type: ACTIONS.UPDATE_TYPO_LOADING })
-
-      const updatedTypo: any[] = [...state.typologies]
-
-      updatedTypo[index].result = msg.result
-
-      let interThreshold = null
-      let alertThreshold = null
-
-      if (Object.keys(msg.workflow).includes("interdictionThreshold")) {
-        interThreshold = msg.workflow.interdictionThreshold
-      }
-
-      if (Object.keys(msg.workflow).includes("alertThreshold")) {
-        alertThreshold = msg.workflow.alertThreshold
-      }
-
-      updatedTypo[index].color = "g"
-
-      if (alertThreshold !== null && interThreshold !== null) {
-        if (msg.result < alertThreshold) {
-          updatedTypo[index].color = "g"
-        } else if (msg.result >= alertThreshold && msg.result < interThreshold) {
-          updatedTypo[index].color = "y"
-        } else if (msg.result >= interThreshold) {
-          updatedTypo[index].color = "r"
-          updatedTypo[index].stop = true
-        }
-      }
-      if (alertThreshold !== null && interThreshold === null) {
-        if (msg.result < alertThreshold) {
-          updatedTypo[index].color = "g"
-        } else if (msg.result >= alertThreshold) {
-          updatedTypo[index].color = "y"
-        }
-      } else {
-        if (msg.result < 0) {
-          updatedTypo[index].color = "y"
-        }
-      }
-
+      const updatedTypo = applyTypologyUpdate(state.typologies, index, msg)
       dispatch({ type: ACTIONS.UPDATE_TYPO_SUCCESS, payload: updatedTypo })
     } catch (error: any) {
       dispatch({ type: ACTIONS.UPDATE_TYPO_FAIL })
@@ -466,48 +481,50 @@ const ProcessorProvider = ({ children }: Props) => {
 
     try {
       dispatch({ type: ACTIONS.UPDATE_ADJUDICATOR_LOADING })
-      await data.results.forEach(async (result) => {
-        result.ruleResults.map(async (ruleResult) => {
-          if (efrupIdRef.current !== undefined && ruleResult.id === efrupIdRef.current) {
-            const index = await state.rules.findIndex((r: Rule) => r.rule === ruleResult.id)
 
-            if (!state.rules[index]) {
+      // Build a fresh rules array with new objects so React detects the change
+      // and re-renders the rule lights. The previous implementation mutated
+      // state.rules[i] in place, which silently dropped paint updates because
+      // the array reference never changed.
+      const updatedRules: any[] = state.rules.map((r: Rule) => ({ ...r }))
+
+      data.results.forEach((result) => {
+        result.ruleResults.forEach((ruleResult) => {
+          if (efrupIdRef.current !== undefined && ruleResult.id === efrupIdRef.current) {
+            const index = updatedRules.findIndex((r: Rule) => r.rule === ruleResult.id)
+            if (index === -1) {
               console.log("Missing rule")
               console.dir(state.rules)
               return
             }
-
             if (ruleResult.subRuleRef === "override") {
-              state.rules[index].color = "g"
+              updatedRules[index].color = "g"
             } else if (ruleResult.subRuleRef === "block") {
-              state.rules[index].color = "r"
+              updatedRules[index].color = "r"
             } else if (ruleResult.subRuleRef === "none") {
-              state.rules[index].color = "n"
+              updatedRules[index].color = "n"
             }
-            state.rules[index].result = ruleResult.subRuleRef
+            updatedRules[index].result = ruleResult.subRuleRef
           } else {
-            const index = await state.rules.findIndex((r: Rule) => r.title === ruleResult.id.split("@")[0])
-            if (index !== -1) {
-              if ((ruleResult.wght ?? 0) > 0) {
-                state.rules[index].result = ruleResult.subRuleRef
-
-                state.rules[index].color = "r"
-
-                if (state.rules[index].wght < (ruleResult.wght ?? 0)) state.rules[index].wght = ruleResult.wght
-
-                if (!resIndex.includes(index)) {
-                  resIndex.push({ index: index, wght: ruleResult.wght })
-                }
-              } else {
-                state.rules[index].result = ruleResult.subRuleRef
-                state.rules[index].color = "g"
-                state.rules[index].wght = ruleResult.wght
+            const index = updatedRules.findIndex((r: Rule) => r.title === ruleResult.id.split("@")[0])
+            if (index === -1) return
+            if ((ruleResult.wght ?? 0) > 0) {
+              updatedRules[index].result = ruleResult.subRuleRef
+              updatedRules[index].color = "r"
+              if (updatedRules[index].wght < (ruleResult.wght ?? 0)) updatedRules[index].wght = ruleResult.wght
+              if (!resIndex.includes(index)) {
+                resIndex.push({ index: index, wght: ruleResult.wght })
               }
+            } else {
+              updatedRules[index].result = ruleResult.subRuleRef
+              updatedRules[index].color = "g"
+              updatedRules[index].wght = ruleResult.wght
             }
           }
         })
       })
 
+      dispatch({ type: ACTIONS.UPDATE_RULES_SUCCESS, payload: updatedRules })
       dispatch({ type: ACTIONS.UPDATE_ADJUDICATOR_SUCCESS, payload: data })
     } catch (error) {
       dispatch({ type: ACTIONS.UPDATE_ADJUDICATOR_FAIL })

--- a/store/processors/processor.provider.tsx
+++ b/store/processors/processor.provider.tsx
@@ -81,6 +81,12 @@ const ProcessorProvider = ({ children }: Props) => {
   const [socket, setSocket] = useState<Socket>()
   const [isConnected, setIsConnected] = useState<boolean>(false)
   const [wsAddress, setWsAddress] = useState<string>(process.env.NEXT_PUBLIC_WS_URL ?? "")
+  // Counter bumped by triggerClearAll() so the page-level component can
+  // subscribe via useEffect and flush its local selection / hover state
+  // when the header Clear All button is clicked. Starts at 0; effects guard
+  // against the initial-mount fire.
+  const [clearAllSignal, setClearAllSignal] = useState<number>(0)
+  const triggerClearAll = () => setClearAllSignal((n) => n + 1)
   const msgId: any = useRef("")
   const efrupIdRef = useRef<string | undefined>(undefined)
   // Holds the most recent eventAdjudicator message that arrived before
@@ -1094,6 +1100,8 @@ const ProcessorProvider = ({ children }: Props) => {
         setShowCreditorConditionsCreate,
         setLinkedTypologies,
         clearLinkedTypologies,
+        clearAllSignal,
+        triggerClearAll,
       }}
     >
       {children}

--- a/store/processors/processor.provider.tsx
+++ b/store/processors/processor.provider.tsx
@@ -83,6 +83,12 @@ const ProcessorProvider = ({ children }: Props) => {
   const [wsAddress, setWsAddress] = useState<string>(process.env.NEXT_PUBLIC_WS_URL ?? "")
   const msgId: any = useRef("")
   const efrupIdRef = useRef<string | undefined>(undefined)
+  // Holds the most recent eventAdjudicator message that arrived before
+  // the network-map-driven state (state.rules / state.typologies) had
+  // finished loading. The drain useEffect below replays it once the
+  // state is ready, so a fast Tazama pipeline that beats the network-map
+  // fetch does not silently drop the message and leave the lights blank.
+  const pendingAdjudicatorMsg = useRef<any>(null)
 
   useEffect(() => {
     try {
@@ -135,13 +141,22 @@ const ProcessorProvider = ({ children }: Props) => {
   }, [state.linkedTypologies, state.rules])
 
   useEffect(() => {
+    // Guard against the page-load race: until state.rules has been
+    // populated by createUIFromNetworkMap, every findIndex in
+    // updateTadpLights would return -1 and we would dispatch an empty
+    // rules array, wiping the just-loaded rules. The deps include
+    // state.rules.length so when it transitions from 0 to N this effect
+    // re-fires and processes any tadProcResults that was buffered while
+    // we were waiting. UPDATE_RULES_SUCCESS keeps the length unchanged,
+    // so no infinite loop.
+    if (state.rules.length === 0) return
     const test = { ...state.tadProcResults }
     if ("results" in test) {
       if (test.results.length > 0) {
         updateTadpLights(state.tadProcResults)
       }
     }
-  }, [state.tadProcResults])
+  }, [state.tadProcResults, state.rules.length])
 
   useEffect(() => {
     const newSocket: any = io(wsAddress!, {
@@ -201,6 +216,16 @@ const ProcessorProvider = ({ children }: Props) => {
       if (currentMsgId && incomingMsgId && incomingMsgId !== currentMsgId) return
       const tadpResult = msg?.report?.tadpResult
       if (!tadpResult || !Object.keys(tadpResult).includes("typologyResult")) return
+      // Page-load race guard: if the network-map driven state has not been
+      // populated yet, stash the message in a ref and let the drain effect
+      // below replay it once state.typologies / state.rules are loaded.
+      // Without this, every typology findIndex returns -1 and the message
+      // is silently dropped (lights blank intermittently when the Tazama
+      // pipeline finishes before /api/network-map).
+      if (state.typologies.length === 0 || state.rules.length === 0) {
+        pendingAdjudicatorMsg.current = msg
+        return
+      }
       const typoResults: any[] = tadpResult.typologyResult ?? []
       // Build the next typologies array in one pass and dispatch once, so a
       // burst of typology results does not race against React's render cycle
@@ -220,6 +245,23 @@ const ProcessorProvider = ({ children }: Props) => {
       }
     }
   })
+
+  // Drain a pending eventAdjudicator message once the network-map driven
+  // state is ready. Both lengths are in deps because the adjudicator
+  // pipeline needs both rules (for updateTadpLights, fed via
+  // SET_ADJUDICATOR_RESULTS dispatched from app/(demo)/page.tsx's G-socket)
+  // and typologies (for the P-socket handler above).
+  useEffect(() => {
+    if (state.rules.length === 0 || state.typologies.length === 0) return
+    const pending = pendingAdjudicatorMsg.current
+    if (!pending) return
+    pendingAdjudicatorMsg.current = null
+    // Re-feed through the adjudicator handler ref so the same code path
+    // runs. handleAdjudicatorLive feeds the rule pipeline via
+    // SET_ADJUDICATOR_RESULTS; the typology side is handled by the ref.
+    adjudicatorHandlerRef.current(pending)
+    handleAdjudicatorLive(pending)
+  }, [state.rules.length, state.typologies.length])
 
   useEffect(() => {
     if (!socket) return

--- a/store/processors/processor.reducer.tsx
+++ b/store/processors/processor.reducer.tsx
@@ -251,13 +251,13 @@ const ProcessorReducer = (state: any, action: any) => {
       return {
         ...state,
         typologyLoading: false,
-        typology: action.payload,
+        typologies: action.payload,
       }
     case ACTIONS.UPDATE_TYPO_FAIL:
       return {
         ...state,
         typologyLoading: false,
-        typology: [],
+        typologies: [],
       }
 
     case ACTIONS.UPDATE_ADJUDICATOR_LOADING:


### PR DESCRIPTION
## Summary

Fixes a bug introduced by the redirect-propagation change in #118: when `AUTHENTICATED=true`, public-folder image references (light icons, logos, fonts, etc.) failed to load and the server console filled with `received null` errors. The bug only surfaced under auth because the new middleware redirect now intercepts every unmatched path, including paths that the Next.js image optimizer needs to fetch internally for itself.

## Root cause

`StatusIndicator` (and other components) reference public-folder assets by literal string path, e.g. `<Image src="/neutral-light-1.png" />`. Next.js rewrites this to `/_next/image?url=%2Fneutral-light-1.png&...` so two fetches happen:

1. **Browser -> `/_next/image?...`** carries the session cookie. The matcher excludes `/_next/image`, so middleware doesn't run. Fine.
2. **Image optimizer (server-side) -> `/neutral-light-1.png`** is an internal HTTP request the optimizer makes to itself to read the source bytes. It has **no cookies**. Its path is NOT excluded by the previous matcher, so middleware runs, sees `request.auth === null`, and (thanks to #118) redirects it to `/login?callbackUrl=%2Fneutral-light-1.png`. The optimizer receives HTML, fails to decode it as an image, logs `received null`.

The login page's logo and tree image worked because they are imported as ES modules, which Next resolves at build time to hashed URLs under `/_next/static/media/...` (already excluded by the matcher). Only string-path image references hit the bug.

Why this didn't bite before #118: the same internal fetch was happening, but the redirect target was the bare `/login` and the dev server's `next/image` was more lenient. The matcher gap was latent; the redirect-propagation fix made it visible.

## Fix

Extend the matcher to also exclude paths ending in common static-asset extensions. Public-folder assets are public by design, so exempting them from auth checks is the correct behaviour and the standard Next.js pattern.

```diff
- "/((?!api|_next/static|_next/image|favicon.ico).*)"
+ "/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:png|jpg|jpeg|svg|gif|webp|ico|css|js|map|woff2?|ttf|eot|otf)$).*)"
```

The expanded comment in `middleware.ts` records the rationale inline so future readers don't have to re-derive it.

## Tests

The matcher is enforced by the Next.js runtime above the handler layer, so the existing handler-level tests cannot exercise it. Added a new `describe("middleware - config.matcher", ...)` block that compiles `config.matcher[0]` into a `RegExp` and probes it directly. 21 new cases across three groups:

| Group | Assertion | Examples |
|---|---|---|
| Application paths | match (middleware runs) | `/`, `/login`, `/dashboard`, `/reports/xyz`, `/login/forgot-password` |
| Next.js internals | excluded (middleware bypassed) | `/api/version`, `/api/auth/callback/credentials`, `/_next/static/chunks/main.js`, `/_next/image`, `/favicon.ico` |
| Public-folder static assets (the bug class) | excluded (so optimizer's internal fetch is not redirected) | `/neutral-light-1.png`, `/green-light-1.png`, `/tazamaLogo.svg`, `/treeImage.png`, `/some/nested/asset.webp`, `/fonts/inter.woff2`, `/styles/site.css` |

### Red-green verification

Reverted the matcher in `middleware.ts` to the pre-fix string, kept the new test cases, and confirmed every public-folder-assets case fails (matcher returns `true`, test expects `false`). Restored the fix and all 21 new cases pass alongside the 8 existing ones.

## Verification

- `npm test` -> **440 passed, 27 suites** (added 2 cases to `nats-helpers.test.ts` alongside the +21 from the matcher work)
- `npm run lint` -> clean, only pre-existing warnings in `RuleResults.tsx` / `TypologyResults.tsx`
- Pre-commit hooks ran via husky (`-s` sign-off verified by `dco-check.yml`-compatible trailer)
- End-to-end: `AUTHENTICATED=true`, fresh login in an Incognito window, submit a transaction -> rule and typology lights paint correctly against the network map loaded into local state

## Risk

Very low. The matcher change is additive (excludes more paths from middleware; never includes new ones). The new excluded paths were already meant to be public (they live in `public/` by definition). No application route uses one of these file extensions as part of its path.

## Secondary fix: `updateTypologies` crash guard

While diagnosing why rule and typology lights were not painting after submitting a transaction (separate session, same branch), `updateTypologies` in `store/processors/processor.provider.tsx` was found to crash with `Cannot set properties of undefined` whenever an incoming event-adjudicator message carried a typology `cfg` that did not appear in the network map loaded into local state. The function called `findIndex` after dispatching the loading action and then unconditionally dereferenced `updatedTypo[index]`, with no check for the `-1` return.

The fix:

- moves the `findIndex` ahead of the loading dispatch
- hardens the cfg lookup with optional chaining (`msg?.cfg?.split("@")?.[0]`)
- returns early when no matching typology is loaded, so the reducer is not driven into a loading state that will never complete

Net diff for this commit: +2 / -1 in one file.

## Tertiary fix: tenant filter read the wrong field

The decoded NATS payload from the event-adjudicator follows the frms-coe-lib pacs.002/pacs.008 envelope, where the tenant id lives at `transaction.TenantId`. The inline `filterByTenantId` in `server.js` and its `lib/nats-helpers.ts` twin were both reading `message.TenantId` at the top level, which is always `undefined` for that envelope - and the existing unit tests pinned the wrong shape too, so the bug was invisible.

The result: under `AUTHENTICATED=true` the filter rejected every real event-adjudicator message and no lights painted. Under `AUTHENTICATED=false` the bug was masked because the call site in `ensureGlobalSub` short-circuits on `socket.data.tenantId != null` (passthrough mode), so the filter is never invoked.

The fix in this commit:

- reads `message.transaction?.TenantId` in both implementations
- documents the envelope shape in the JSDoc of `lib/nats-helpers.ts` and the equivalent block comment in `server.js`
- updates the 5 existing `nats-helpers.test.ts` cases to use the nested shape
- adds two new cases: a missing-`transaction`-block guard, and an explicit regression test asserting a top-level `TenantId` is **ignored** even when it matches the expected tenant id

This is what actually unblocked the lights end-to-end under `AUTHENTICATED=true`. Bundling onto this PR avoids the noise of a separate PR for what is effectively a single misplaced property read; all three commits are signed and individually atomic for clean reverts.

## Quaternary fix: live light pipeline had four structural bugs

End-to-end smoke testing surfaced a separate class of bug: live rule, typology and EVENT ADJUDICATOR lights only painted intermittently, even after the tenant-filter fix unblocked the event-adjudicator messages. Tracing the live result pipeline through `store/processors/processor.provider.tsx` and `store/processors/processor.reducer.tsx` turned up four structural defects that were compounding each other.

### 1. Reducer wrote typology updates to a non-existent field

`UPDATE_TYPO_SUCCESS` and `UPDATE_TYPO_FAIL` set `state.typology` (singular) when every consumer (`state.typologies.findIndex`, `state.typologies.map`, the demo page, the existing `RESET_*` reducers, etc.) reads `state.typologies`. Every typology update was silently discarded at the reducer. Lights only painted when an unrelated re-render coincided with the in-place rule mutation from `updateTadpLights` (bug #4 below) - which explains the "intermittent" symptom.

The existing reducer test asserted `next.typology` and explicitly documented the typo (`// Note: UPDATE_TYPO_SUCCESS stores to 'typology' (singular), not 'typologies'`), pinning the bug. Reducer fixed to write `typologies`; test updated to assert the corrected shape.

### 2. Socket listener accumulated stale closures

The `eventAdjudicator` handler was registered inside a `useEffect` keyed on `[state.typologies]` with no `socket.off` cleanup. Each typology update added another listener bound to a stale `state.typologies` snapshot, so message N triggered N handler invocations and the resulting paint was determined by whichever stale closure landed last (race).

Replaced with the standard React stable-callback-via-ref pattern:

- `adjudicatorHandlerRef.current` is refreshed on every render so the active handler always reads the current `state.typologies` and `currentMsgIdRef.current`
- a single listener is registered against the socket in a `useEffect([socket])` and properly removed via `socket.off` in the cleanup function

### 3. Random `setTimeout` delay inside the handler

The handler scheduled each typology result via `setTimeout(..., Math.floor(Math.random() * (500 - 200)) + 200)`. The random 200-499ms delay introduced nondeterministic ordering and amplified bug #2 (the more time between dispatches, the more stale listeners had registered). Removed. The handler now folds all typology results in one message into a single `nextTypologies` array and dispatches `UPDATE_TYPO_SUCCESS` once, eliminating the read-modify-write race that the per-typology dispatches would otherwise hit (each dispatch reads the same `state.typologies` snapshot and overwrites its predecessor's update).

A new `applyTypologyUpdate(typologies, idx, msg)` helper was extracted so both the existing per-message `updateTypologies` path and the batched eventAdjudicator path share one threshold-evaluation routine.

### 4. `updateTadpLights` mutated `state.rules` in place

`updateTadpLights` directly assigned `state.rules[index].color = "r"`, `state.rules[index].result = ruleResult.subRuleRef`, `state.rules[index].wght = ruleResult.wght`. The array reference never changed, so even though `UPDATE_ADJUDICATOR_SUCCESS` was dispatched, the reducer never saw a new `rules` reference and React never re-rendered the rule lights. The function also used `await data.results.forEach(async ...)` which is a known anti-pattern (`forEach` ignores the returned promise; the outer `await` does nothing).

Refactored to:

- build a fresh `updatedRules = state.rules.map((r) => ({ ...r }))` so every rule object is a new reference
- apply all rule-result updates against `updatedRules`
- dispatch `UPDATE_RULES_SUCCESS` with the new array alongside `UPDATE_ADJUDICATOR_SUCCESS`
- replace `forEach(async ...)` with plain synchronous `forEach`

### Verification

- `npm test` -> **440 passed, 27 suites**
- Reducer test now asserts the corrected `typologies` field for `UPDATE_TYPO_SUCCESS` / `UPDATE_TYPO_FAIL`
- No lint or type errors

This is the commit that actually delivers reliable live lights end-to-end. Bundled onto the same PR because it shares the same diagnostic chain as the tertiary fix; both required `AUTHENTICATED=true` to reproduce and would not have been visible from the test-mode synthetic pipeline.

## Quinary fix: socket leak and NATS queue group

After the quaternary fix landed I still saw intermittent failures - five submissions would paint correctly, then one would land in the entity reducer but never trigger `handleAdjudicatorLive`. Browser console showed the live log line `LIVE: <msgId> 2` (count = 2) every time a message *did* arrive. Server log showed three `Client connected` lines per browser tab, each followed shortly by `Client disconnected`. Two compounding root causes.

### 1. Client-side Socket.IO leak in `app/(demo)/page.tsx`

The initializer assigned to a module-scope `socket` variable from an async closure:

```tsx
let socket: ReturnType<typeof io> | undefined  // module scope

useEffect(() => {
  const socketInitializer = async () => {
    await fetch("/api/health")
    socket = io()
    socket.on("eventAdjudicator", ...)
  }
  socketInitializer()
  return () => { if (socket) { socket.off(...); socket.disconnect() } }
}, [])
```

React 18 Strict Mode mounts every effect twice in dev, and Fast Refresh re-runs them on every save, but the `await fetch("/api/health")` suspends past the cleanup window:

1. First mount fires the effect, initializer suspends on fetch
2. Strict Mode unmount runs cleanup - `socket` is still `undefined`, no-op
3. Strict Mode remount fires a second initializer, also suspends
4. Both fetches resolve, each calls `socket = io()` - the second overwrites the module var, but both connections are alive on the server
5. Subsequent Fast Refresh adds a third

The server log confirmed: every page session produced three connections, all from this one browser. The `2` count next to each `LIVE:` log came from the two leaked connections that still had their listener closures intact.

The intermittent miss happened when the server tore down a stale leaked socket on its heartbeat timeout in the same narrow window that a new NATS message arrived. The active client-side listener was on a socket the server had just reaped, and the freshly bound socket was still being negotiated. The message reached zero live listeners and was silently dropped.

Fix: capture the socket in a closure-local with an `aborted` flag. Each effect run owns its own connection; cleanup tears down exactly the socket it created regardless of when the await resolves:

```tsx
useEffect(() => {
  let aborted = false
  let localSocket: ReturnType<typeof io> | undefined
  ;(async () => {
    await fetch("/api/health")
    if (aborted) return
    localSocket = io()
    socket = localSocket
    localSocket.on("eventAdjudicator", ...)
    // ...other listeners
  })()
  return () => {
    aborted = true
    if (localSocket) {
      localSocket.off(...); localSocket.disconnect()
    }
  }
}, [])
```

Server log after the fix should show 1-2 stable clients per tab (one from `page.tsx`, one from `processor.provider.tsx`), no churn.

### 2. NATS queue group `DEMO_MONITORING` in `server.js`

Both `ensureGlobalSub` and `ensureTenantSub` subscribed with `{ queue: "DEMO_MONITORING" }`. NATS queue groups load-balance: when N subscribers register the same `(subject, queue)`, NATS picks one at random per message and the others receive nothing. That is the opposite of what a UI observer wants - each demo backend must receive every message and fan it out to its own Socket.IO clients.

With one backend the queue group was a no-op. With two backends (two devs running locally, a deployed instance + a local dev, a leftover crashed process still subscribed), each viewer saw a random ~50% of their own pipeline events. With N, each saw 1/N. Counter-intuitively, removing the queue group is what *enables* multi-instance coexistence, not what breaks it.

Fix: drop the `queue` option from both subscriptions. Tenant filtering still happens server-side at emit time via `socket.data.tenantId`.

### Verification

- `npm test` -> **440 passed, 27 suites**
- Server log after restart: client connection count per tab dropped from 3 to 1-2 (stable)
- Browser console: `LIVE: <msgId>` count is now `1`, no leaked listeners

## Header UX (Clear All / Logout / username)

Three small UX fixes bundled because they share the same surface area (the demo-page header) and the same root cause - the header zone had grown organically across PR #118 and the AUTHENTICATED feature, without anyone reconciling who owned which pixels.

### 1. Clear All button moved into the layout header

The Clear All button was rendered from `app/(demo)/page.tsx` as `z-99 absolute right-[100px] top-5` and parachuted on top of the header bar managed by `app/(demo)/layout.tsx`. When the AUTHENTICATED feature added a HeaderUserInfo block (name / Tenant / Logout) to the right of the header, the absolute-positioned Clear All slab overlapped the right end of that block, cramping the `Tenant: DEFAULT` text. The hardcoded `right-[100px]` offset was fragile too - any new header item would have required re-tuning it.

Moved into the header flex container as a sibling of HeaderUserInfo so the browser layout engine handles spacing. Order in the right-side group is now `[name/tenant]  [Clear All]  [Logout]`. Logout stays in the top-right corner.

The page-level click handler still owns local selection / hover state, so the button signals via a new `clearAllSignal` counter on `ProcessorContext`. `triggerClearAll()` bumps it; `page.tsx` subscribes via `useEffect` and flushes its eight local setters alongside the four context-side clears (`clearLinkedTypologies`, `clearUIData`, `resetAllLights`, `clearResults`). The initial-mount fire is guarded by checking `signal === 0` to avoid a gratuitous clear on page load.

- New client component: `components/Header/ClearAllButton.tsx`
- `HeaderUserInfo` extended with an optional `children` slot rendered between the tenant text and the Logout button so the layout can inline the Clear All button into the same flex row

### 2. Logout button restyled to match Clear All

Logout was using `border border-gray-300 bg-white px-3 py-1.5 text-xs` while Clear All used the gradient-slab style that matches the header bar itself. Aligned Logout to the slab style and added a subtle border / hover / active treatment to both buttons:

```
rounded-md border border-gray-300 bg-gradient-to-b from-gray-100 to-gray-200 p-2 shadow-lg hover:from-gray-200 hover:to-gray-300 active:shadow-md
```

They now read as a coherent pair of raised slabs on the header surface.

### 3. Header displays the signed-in username instead of "User"

`layout.tsx` reads:

```ts
displayName = session.user?.name ?? session.user?.email ?? "User"
```

but the Credentials provider's `authorize()` in `lib/auth.ts` only returned `{ id, accessToken }` - never populating `name` or `email` - so the header always fell through to the literal `"User"` string.

Set `name: credentials.username` on the `authorize()` return so NextAuth auto-copies it through the `jwt` and `session` callbacks. The header now shows whatever the user typed at the login form. We do not have an email address (the auth-service returns only a JWT); adding JWT claim extraction can come later if the auth-service contract is documented.

### Verification

- `npm test` -> **440 passed, 27 suites**
- Browser: header shows `[username]  Tenant: DEFAULT  [Clear All]  [Logout]`, both buttons share styling, no overlap with tenant text

## Test env (`.env.test`)

The pre-push husky hook runs `npm test`, and a subset of BFF route tests fail when `AUTHENTICATED=true` because their route handlers branch to the auth-required path and return 401 (the mocked `auth()` returns undefined). Developers running with the now-default `AUTHENTICATED=true` in their `.env` had to remember to prepend `$env:AUTHENTICATED = "false"` before every `git push` to pass the hook.

`next/jest` auto-loads `.env.test` for the test environment via `@next/env` and it takes precedence over `.env`. Adding it with `AUTHENTICATED=false` makes the suite self-contained: no shell ritual required.

The pattern of explicit overrides is preserved where it matters. The dedicated `bff-*-auth.test.ts` files already set `process.env.AUTHENTICATED = "true"` at the top of the file before importing the route under test, so they continue to exercise the auth-on code path unchanged.

### Verification

- Cleared the shell `$env:AUTHENTICATED`, left `.env` at `AUTHENTICATED=true`, ran `npm test`: **440 passed, 27 suites**
- `.env.test` is not blocked by `.gitignore` (which only excludes `.env`, `.env.local`, `.env.*.local`), so the override is shared across the team

## Related


- #118 - introduced callbackUrl propagation; surfaced this latent gap
- The `Rule` / `Typology` aggregate refactor sketched in the rules-panel walkthrough is unaffected by this fix; both today's `StatusIndicator` (string-path PNG references) and the proposed `RuleLight` projection would benefit from the matcher being correct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “Clear All” header control that triggers page-wide UI resets; header shows the button conditionally.

* **Bug Fixes**
  * Middleware now excludes framework internals and common static assets to avoid unwanted redirects.
  * Tenant filtering now reads tenant id from the correct envelope location so messages aren’t dropped.
  * Socket handling improved to prevent duplicate connections under Strict Mode.

* **Tests**
  * Added route-protection tests and tenant-envelope unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




