### PR TITLE
fix: handle admin-service rule cases object shape, narrow per-call error reporting, and fix RuleResult hook violation

### DIFF
--- a/__tests__/bff-network-map.test.ts
+++ b/__tests__/bff-network-map.test.ts
@@ -100,33 +100,74 @@ describe("GET /api/network-map", () => {
     expect(body).toEqual({ rules: [], typologies: [], typologiesEFRuP: [] })
   })
 
-  it("mirrors the status code from TazamaClientError", async () => {
-    mockAdminGet.mockRejectedValueOnce(new TazamaClientError(503, "Service unavailable"))
+  it("mirrors the status from a TazamaClientError and reports the failing source (network_map)", async () => {
+    mockAdminGet
+      .mockRejectedValueOnce(new TazamaClientError(503, "Service unavailable"))
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [] })
 
     const response = await GET()
     const body = await response.json()
 
     expect(response.status).toBe(503)
-    expect(body.error).toBe("Service unavailable")
+    expect(body.failures).toEqual([{ source: "network_map", status: 503, message: "Service unavailable" }])
+    expect(body.error).toContain("network_map")
   })
 
-  it("returns 504 for a DOMException TimeoutError", async () => {
-    mockAdminGet.mockRejectedValueOnce(new DOMException("timed out", "TimeoutError"))
+  it("returns 504 for a DOMException TimeoutError on the rule call and identifies the source", async () => {
+    mockAdminGet
+      .mockResolvedValueOnce({ data: [] })
+      .mockRejectedValueOnce(new DOMException("timed out", "TimeoutError"))
+      .mockResolvedValueOnce({ data: [] })
 
     const response = await GET()
     const body = await response.json()
 
     expect(response.status).toBe(504)
-    expect(body.error).toContain("timed out")
+    expect(body.failures).toHaveLength(1)
+    expect(body.failures[0]).toMatchObject({ source: "rule", status: 504 })
+    expect(body.failures[0].message).toMatch(/timed out/i)
   })
 
-  it("returns 502 for any other unexpected error", async () => {
-    mockAdminGet.mockRejectedValueOnce(new Error("connection refused"))
+  it("returns 502 for an unexpected error on the typology call and identifies the source", async () => {
+    mockAdminGet
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [] })
+      .mockRejectedValueOnce(new Error("connection refused"))
 
     const response = await GET()
     const body = await response.json()
 
     expect(response.status).toBe(502)
-    expect(body.error).toContain("Failed to reach")
+    expect(body.failures).toHaveLength(1)
+    expect(body.failures[0]).toMatchObject({ source: "typology", status: 502 })
+  })
+
+  it("reports every failed source and uses the worst status when multiple calls fail", async () => {
+    mockAdminGet
+      .mockRejectedValueOnce(new TazamaClientError(503, "nm down"))
+      .mockRejectedValueOnce(new DOMException("timed out", "TimeoutError"))
+      .mockResolvedValueOnce({ data: [] })
+
+    const response = await GET()
+    const body = await response.json()
+
+    // 504 (timeout) > 503 (service unavailable) -> worst status wins.
+    expect(response.status).toBe(504)
+    expect(body.failures).toHaveLength(2)
+    expect(body.failures.map((f: { source: string }) => f.source).sort()).toEqual(["network_map", "rule"])
+  })
+
+  it("succeeds when admin-service calls succeed even if one of them returns an empty list", async () => {
+    mockAdminGet
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [] })
+
+    const response = await GET()
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.failures).toBeUndefined()
   })
 })

--- a/__tests__/network-map-transform.test.ts
+++ b/__tests__/network-map-transform.test.ts
@@ -119,7 +119,39 @@ describe("transformNetworkMap", () => {
     expect(out.rules[0].ruleBands[0]).toEqual({ subRuleRef: ".01", lowerLimit: 0, upperLimit: 100, reason: "low" })
   })
 
-  it("hydrates rules from the `cases` config shape", () => {
+  it("hydrates rules from the `cases` config shape (admin-service: { expressions, alternative })", () => {
+    const networkMap = {
+      data: [{ messages: [{ typologies: [{ cfg: "999@1.0.0", rules: [{ id: "901@1.0.0" }] }] }] }],
+    }
+    // Real admin-service shape (e.g. rule 078@1.0.0): `cases` is an object, not an array.
+    const rules = {
+      data: [
+        {
+          id: "901@1.0.0",
+          desc: "Cases rule",
+          config: {
+            cases: {
+              expressions: [
+                { subRuleRef: ".01", reason: "MP2B match", value: "MP2B" },
+                { subRuleRef: ".02", reason: "MP2P match", value: "MP2P" },
+              ],
+              alternative: { subRuleRef: ".00", reason: "unrecognised" },
+            },
+          },
+        },
+      ],
+    }
+
+    const out = transformNetworkMap(networkMap, rules, { data: [] })
+
+    expect(out.rules[0].ruleBands).toEqual([
+      { subRuleRef: ".01", lowerLimit: null, upperLimit: null, reason: "MP2B match" },
+      { subRuleRef: ".02", lowerLimit: null, upperLimit: null, reason: "MP2P match" },
+      { subRuleRef: ".00", lowerLimit: null, upperLimit: null, reason: "unrecognised" },
+    ])
+  })
+
+  it("hydrates rules from `cases` with only expressions (no alternative)", () => {
     const networkMap = {
       data: [{ messages: [{ typologies: [{ cfg: "999@1.0.0", rules: [{ id: "901@1.0.0" }] }] }] }],
     }
@@ -127,15 +159,19 @@ describe("transformNetworkMap", () => {
       data: [
         {
           id: "901@1.0.0",
-          desc: "Cases rule",
-          config: { cases: [{ subRuleRef: ".01", lowerLimit: null, upperLimit: null, reason: "match" }] },
+          desc: "Cases rule no alt",
+          config: {
+            cases: {
+              expressions: [{ subRuleRef: ".01", reason: "only", value: "X" }],
+            },
+          },
         },
       ],
     }
 
     const out = transformNetworkMap(networkMap, rules, { data: [] })
 
-    expect(out.rules[0].ruleBands).toEqual([{ subRuleRef: ".01", lowerLimit: null, upperLimit: null, reason: "match" }])
+    expect(out.rules[0].ruleBands).toEqual([{ subRuleRef: ".01", lowerLimit: null, upperLimit: null, reason: "only" }])
   })
 
   it("appends `exitConditions` to ruleBands in addition to bands/cases", () => {

--- a/__tests__/rules.test.ts
+++ b/__tests__/rules.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { Rule } from "store/processors/processor.interface"
+import { getRuleDescriptions } from "utils/rules"
+
+const rule = (overrides: Partial<Rule> = {}): Rule =>
+  ({
+    id: 901,
+    title: "901",
+    rule: "901@1.0.0",
+    ruleDescription: "",
+    color: "n",
+    result: null,
+    wght: 0,
+    linkedTypologies: [],
+    ruleBands: [],
+    displayLinkedTypo: [],
+    ...overrides,
+  }) as unknown as Rule
+
+describe("getRuleDescriptions (pure)", () => {
+  it("returns the matching band reason for a known rule + subRuleRef", () => {
+    const rules: Rule[] = [
+      rule({
+        id: 901,
+        ruleBands: [
+          { subRuleRef: ".01", lowerLimit: 0, upperLimit: 1, reason: "low" },
+          { subRuleRef: ".02", lowerLimit: 1, upperLimit: 2, reason: "high" },
+        ] as Rule["ruleBands"],
+      }),
+    ]
+    expect(getRuleDescriptions(rules, ".02", 901)).toBe("high")
+  })
+
+  it("returns undefined when the rule_id is not in the rule list (no NPE)", () => {
+    const rules: Rule[] = [rule({ id: 901, ruleBands: [] as Rule["ruleBands"] })]
+    expect(() => getRuleDescriptions(rules, ".01", 999)).not.toThrow()
+    expect(getRuleDescriptions(rules, ".01", 999)).toBeUndefined()
+  })
+
+  it("returns undefined when the subRuleRef is not in the rule's bands", () => {
+    const rules: Rule[] = [
+      rule({
+        id: 901,
+        ruleBands: [{ subRuleRef: ".01", lowerLimit: 0, upperLimit: 1, reason: "low" }] as Rule["ruleBands"],
+      }),
+    ]
+    expect(getRuleDescriptions(rules, ".99", 901)).toBeUndefined()
+  })
+
+  it("tolerates a rule whose ruleBands is missing/undefined", () => {
+    const rules: Rule[] = [rule({ id: 901, ruleBands: undefined as unknown as Rule["ruleBands"] })]
+    expect(() => getRuleDescriptions(rules, ".01", 901)).not.toThrow()
+    expect(getRuleDescriptions(rules, ".01", 901)).toBeUndefined()
+  })
+})

--- a/app/api/network-map/route.ts
+++ b/app/api/network-map/route.ts
@@ -11,6 +11,29 @@ type NetworkMapResponse = NonNullable<Parameters<typeof transformNetworkMap>[0]>
 type RuleResponse = NonNullable<Parameters<typeof transformNetworkMap>[1]>
 type TypologyResponse = NonNullable<Parameters<typeof transformNetworkMap>[2]>
 
+// Tuple kept in lock-step with the Promise.allSettled below so each settled
+// result can be tagged with the upstream endpoint name. Used in the failure
+// response body so operators can see which admin-service call(s) broke.
+const SOURCES = ["network_map", "rule", "typology"] as const
+type Source = (typeof SOURCES)[number]
+
+interface Failure {
+  source: Source
+  status: number
+  message: string
+}
+
+function toFailure(source: Source, err: unknown): Failure {
+  if (err instanceof TazamaClientError) {
+    return { source, status: err.status, message: err.message }
+  }
+  if (err instanceof DOMException && err.name === "TimeoutError") {
+    return { source, status: 504, message: `${source} request timed out` }
+  }
+  const message = err instanceof Error ? err.message : String(err)
+  return { source, status: 502, message: `Failed to reach admin service for ${source}: ${message}` }
+}
+
 export async function GET() {
   let jwt: string | undefined
 
@@ -22,26 +45,42 @@ export async function GET() {
     jwt = session.accessToken
   }
 
-  try {
-    // The UI store consumer (`createUIFromNetworkMap`) expects a flat, hydrated
-    // shape `{ rules, typologies, typologiesEFRuP }`. v3 produced that shape in
-    // the BFF directly against Postgres; v4 must rebuild it from three
-    // admin-service calls. See issue #116.
-    const [networkMapResponse, ruleResponse, typologyResponse] = await Promise.all([
-      adminGet<NetworkMapResponse>("/v1/admin/configuration/network_map?filters[active]=true", jwt),
-      adminGet<RuleResponse>("/v1/admin/configuration/rule", jwt),
-      adminGet<TypologyResponse>("/v1/admin/configuration/typology", jwt),
-    ])
+  // The UI store consumer (`createUIFromNetworkMap`) expects a flat, hydrated
+  // shape `{ rules, typologies, typologiesEFRuP }`. v3 produced that shape in
+  // the BFF directly against Postgres; v4 must rebuild it from three
+  // admin-service calls. See issues #116, #120.
+  //
+  // Use `allSettled` so that one failing admin call does not mask the others.
+  // Each failure is reported individually with its source endpoint.
+  const settled = await Promise.allSettled([
+    adminGet<NetworkMapResponse>("/v1/admin/configuration/network_map?filters[active]=true", jwt),
+    adminGet<RuleResponse>("/v1/admin/configuration/rule", jwt),
+    adminGet<TypologyResponse>("/v1/admin/configuration/typology", jwt),
+  ])
 
+  const failures: Failure[] = []
+  for (let i = 0; i < settled.length; i++) {
+    const result = settled[i]!
+    if (result.status === "rejected") {
+      failures.push(toFailure(SOURCES[i]!, result.reason))
+    }
+  }
+
+  if (failures.length > 0) {
+    const status = Math.max(...failures.map((f) => f.status))
+    const sources = failures.map((f) => f.source).join(", ")
+    return NextResponse.json({ error: `admin-service call(s) failed: ${sources}`, failures }, { status })
+  }
+
+  const [networkMapResponse, ruleResponse, typologyResponse] = settled.map(
+    (r) => (r as PromiseFulfilledResult<unknown>).value
+  ) as [NetworkMapResponse, RuleResponse, TypologyResponse]
+
+  try {
     const transformed = transformNetworkMap(networkMapResponse, ruleResponse, typologyResponse)
     return NextResponse.json(transformed)
   } catch (err) {
-    if (err instanceof TazamaClientError) {
-      return NextResponse.json({ error: err.message }, { status: err.status })
-    }
-    if (err instanceof DOMException && err.name === "TimeoutError") {
-      return NextResponse.json({ error: "Admin service request timed out" }, { status: 504 })
-    }
-    return NextResponse.json({ error: "Failed to reach admin service" }, { status: 502 })
+    const message = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ error: "Failed to transform admin-service response", message }, { status: 500 })
   }
 }

--- a/components/RuleResults/RuleResults.tsx
+++ b/components/RuleResults/RuleResults.tsx
@@ -18,6 +18,12 @@ interface RuleProps {
 }
 
 const RuleResult = ({ ...props }: RuleProps) => {
+  // Call useContext exactly once per render at the top level - Rules of Hooks.
+  // The lookup was previously done inside getRuleDescriptions which was invoked
+  // from within a .map() callback below; the hook count then varied with
+  // linkedTypologies.length and React would error on re-render. See issue #120.
+  const procCtx = useContext(ProcessorContext)
+
   let ruleTPS: any
   if (props.hoveredRule) {
     ruleTPS = props.hoveredRule?.linkedTypologies.map((tp) => {
@@ -34,7 +40,7 @@ const RuleResult = ({ ...props }: RuleProps) => {
           </div>
           <div className="align-center flex w-full grow items-center border-black text-center text-xs">
             <p className="w-full text-center text-xs">
-              {getRuleDescriptions(tp.subRuleRef, parseFloat(tp.rule)) || "None"}
+              {getRuleDescriptions(procCtx.rules, tp.subRuleRef, parseFloat(tp.rule)) || "None"}
             </p>
           </div>
         </div>
@@ -55,7 +61,7 @@ const RuleResult = ({ ...props }: RuleProps) => {
           </div>
           <div className="align-center flex w-full grow items-center border-black text-center text-xs">
             <p className="w-full text-center text-xs">
-              {getRuleDescriptions(tp.subRuleRef, parseFloat(tp.rule)) || "None"}
+              {getRuleDescriptions(procCtx.rules, tp.subRuleRef, parseFloat(tp.rule)) || "None"}
             </p>
           </div>
         </div>

--- a/lib/network-map-transform.ts
+++ b/lib/network-map-transform.ts
@@ -41,13 +41,24 @@ interface AdminListEnvelope<T> {
   data?: T[]
 }
 
+interface RuleCaseExpression {
+  subRuleRef: string
+  reason: string
+  value?: unknown
+}
+
+interface RuleCases {
+  expressions?: RuleCaseExpression[]
+  alternative?: { subRuleRef: string; reason: string }
+}
+
 interface RuleConfigDoc {
   id?: string
   rule?: string
   desc?: string
   config?: {
     bands?: RuleBand[]
-    cases?: RuleBand[]
+    cases?: RuleCases
     exitConditions?: RuleBand[]
   }
 }
@@ -160,14 +171,36 @@ export function transformNetworkMap(
     const cfg = ruleDoc.config
     if (!cfg) continue
 
-    const sourceBands = (cfg.bands?.length ? cfg.bands : cfg.cases) ?? []
-    for (const band of sourceBands) {
-      rule.ruleBands.push({
-        subRuleRef: band.subRuleRef,
-        lowerLimit: band.lowerLimit ?? null,
-        upperLimit: band.upperLimit ?? null,
-        reason: band.reason,
-      })
+    if (cfg.bands?.length) {
+      for (const band of cfg.bands) {
+        rule.ruleBands.push({
+          subRuleRef: band.subRuleRef,
+          lowerLimit: band.lowerLimit ?? null,
+          upperLimit: band.upperLimit ?? null,
+          reason: band.reason,
+        })
+      }
+    } else if (cfg.cases) {
+      // admin-service `cases` shape: { expressions: [...], alternative?: {...} }.
+      // Each expression / the alternative becomes a band with null limits; the
+      // expression `value` is intentionally dropped because RuleBand has no
+      // slot for it and the UI's lookup in utils/rules.tsx keys on subRuleRef.
+      for (const expr of cfg.cases.expressions ?? []) {
+        rule.ruleBands.push({
+          subRuleRef: expr.subRuleRef,
+          lowerLimit: null,
+          upperLimit: null,
+          reason: expr.reason,
+        })
+      }
+      if (cfg.cases.alternative) {
+        rule.ruleBands.push({
+          subRuleRef: cfg.cases.alternative.subRuleRef,
+          lowerLimit: null,
+          upperLimit: null,
+          reason: cfg.cases.alternative.reason,
+        })
+      }
     }
 
     if (cfg.exitConditions) {

--- a/utils/rules.tsx
+++ b/utils/rules.tsx
@@ -1,6 +1,4 @@
 "use client"
-import { useContext } from "react"
-import ProcessorContext from "store/processors/processor.context"
 import { Rule } from "store/processors/processor.interface"
 
 interface RuleProps {
@@ -16,10 +14,17 @@ interface RuleProps {
   setHoverTypes: (data: any[]) => void
 }
 
-export const getRuleDescriptions = (result: string, rule_id: number) => {
-  const procCtx = useContext(ProcessorContext)
-  const desc: any = procCtx.rules.find((rule: Rule) => rule.id === rule_id)
-  const description = desc.ruleBands.find((item: any) => item.subRuleRef === result)
+/**
+ * Look up the human-readable reason for a rule's sub-result band.
+ *
+ * Pure function on purpose: callers must read `rules` from `ProcessorContext`
+ * once at the top of their component and pass it in, otherwise invoking this
+ * inside a `.map()` violates the Rules of Hooks (the hook count would change
+ * with `linkedTypologies.length`).
+ */
+export const getRuleDescriptions = (rules: Rule[], result: string, rule_id: number): string | undefined => {
+  const desc = rules.find((rule: Rule) => rule.id === rule_id)
+  const description = desc?.ruleBands?.find((item) => item.subRuleRef === result)
   return description?.reason
 }
 


### PR DESCRIPTION
## Summary

Closes #120.

Two related fixes triggered by the admin-service rule contract change. Both showed up after the upstream admin-service bug was repaired and the demo started receiving the real (correct) rule shape.

### 1. `fix(bff)`: handle the `cases` object shape and narrow per-call error reporting

`GET /api/network-map` returned an opaque `502 Failed to reach admin service` whenever the active network map referenced a rule whose `config` used the `cases` shape (e.g. rule `078@1.0.0`, "Transaction type").

Root cause: [`lib/network-map-transform.ts`](../blob/dev/lib/network-map-transform.ts) declared `RuleConfigDoc.config.cases` as `RuleBand[]` and iterated it directly:

```ts
const sourceBands = (cfg.bands?.length ? cfg.bands : cfg.cases) ?? []
for (const band of sourceBands) { ... }
```

The real admin-service shape is an object, not an array:

```json
"cases": {
  "expressions": [
    { "subRuleRef": ".01", "reason": "...", "value": "MP2B" },
    { "subRuleRef": ".02", "reason": "...", "value": "MP2P" }
  ],
  "alternative": { "subRuleRef": ".00", "reason": "..." }
}
```

so `for...of` threw `TypeError: cases is not iterable`. The throw was caught by the route's single shared `try/catch`, which converted it to a generic `502` with no indication of which call broke.

**Changes**

- `lib/network-map-transform.ts`: update `RuleConfigDoc.config.cases` to `{ expressions?: RuleCaseExpression[]; alternative?: { subRuleRef; reason } }` and rewrite the hydration branch. Each `expression` and the `alternative` (when present) becomes a `RuleBand` with `lowerLimit: null, upperLimit: null`. The expression `value` field is dropped because `RuleBand` has no slot for it and the UI's lookup keys on `subRuleRef` alone.
- `app/api/network-map/route.ts`: replace `Promise.all` with `Promise.allSettled`, tag each settled result with its source endpoint name (`network_map | rule | typology`). When any one or more calls fail the response is now:
  ```json
  {
    "error": "admin-service call(s) failed: rule, typology",
    "failures": [
      { "source": "rule", "status": 503, "message": "Service unavailable" },
      { "source": "typology", "status": 504, "message": "typology request timed out" }
    ]
  }
  ```
  The response status is the worst (highest) upstream status across the failures. `TazamaClientError`, `DOMException(TimeoutError)`, and generic errors are classified per-call via a `toFailure` helper. The transform itself is now wrapped in its own `try/catch` returning `500` if hydration throws - clearly distinguishing a transform bug from an upstream-service outage.

### 2. `fix(ui)`: hoist `useContext` out of `.map()` callback in `RuleResult`

When hovering or selecting a rule, the console fired:

```
React has detected a change in the order of Hooks called by RuleResult.
Previous render: useContext, useContext, undefined
Next render:    useContext, useContext, useContext
```

Root cause: `getRuleDescriptions` called `useContext(ProcessorContext)` and was invoked from inside the `.map()` callback in `RuleResult`. The hook count per render therefore equalled `linkedTypologies.length`, so any change in that array between renders changed the hook order. The cases-shape fix amplified the symptom because hydrated rules now carry more bands and link to more typologies, making length transitions more frequent.

**Changes**

- `utils/rules.tsx`: turn `getRuleDescriptions` into a pure function `(rules, result, rule_id) => string | undefined`. Drop the `useContext` call entirely. Add null-safe optional chaining so an unknown `rule_id` no longer NPEs on `desc.ruleBands.find` - it returns `undefined`.
- `components/RuleResults/RuleResults.tsx`: call `useContext(ProcessorContext)` exactly once at the top of `RuleResult` and pass `procCtx.rules` to both `getRuleDescriptions` call sites.

## TDD evidence

All new/updated tests were written red-first.

- `__tests__/network-map-transform.test.ts`: the existing `cases` test was updated to the real `{ expressions, alternative }` shape (plus a no-`alternative` variant). Both failed against the old code with the exact production error: `TypeError: sourceBands is not iterable` at `lib/network-map-transform.ts:164`.
- `__tests__/bff-network-map.test.ts`: the three failure tests were updated to assert the new `failures[]` body shape with the correct `source` for each, plus a new test covers multi-failure reporting and worst-status selection, and a happy-path test confirms `failures` is undefined on success.
- `__tests__/rules.test.ts` (new): pins the pure-function contract for `getRuleDescriptions` - happy path, unknown `rule_id` (no throw), unknown `subRuleRef`, and a rule with no `ruleBands` array. Failed red against the old impl with `Cannot read properties of null (reading 'useContext')` because it tried to call a React hook outside React.

Full suite green: **456/456**.

## Verification

```
npm test     -> 456 passed, 28 suites
npm run lint -> no new warnings on the changed files
npm run build -> clean Next.js build
```

## Out of scope

- The `/api/rules` route passes the admin response through verbatim, so the shape change is invisible there. No changes needed.
- No UI code consumes the `value` field on `cases.expressions`; if a future feature wants per-case `value` rendering, `RuleBand` would need extending and is a separate concern.
- Light-painting flicker reported during dev was traced to render-timing of the network-map fetch vs first NATS frame, not to anything in this PR; the two issues are independent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Network map API now provides structured failure reporting, displaying status and error details for each failing source when issues occur.

* **Bug Fixes**
  * Improved error handling for concurrent operations with proper status aggregation.
  * Enhanced rule description lookup to handle missing or incomplete rule configurations gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->