### PR TITLE
fix: re-base STOP overlay on alerts slice (decouple from legacy adjudicatorLights) (#129)

### DIFF
--- a/__tests__/StopOverlay.test.tsx
+++ b/__tests__/StopOverlay.test.tsx
@@ -1,0 +1,209 @@
+// ─── <StopOverlay /> component tests (red phase, issue #129) ────────────────
+//
+// The StopOverlay component is the new home for the central red octagonal
+// "hand" image, extracted from app/(demo)/page.tsx and re-based onto the
+// alerts slice (eventFlow + typology only).
+//
+// What this file covers:
+//   - The 6-row truth table from issue #129, exercised through the React
+//     context wiring (not the pure function, which is covered by
+//     stopOverlay.test.ts).
+//   - The image carries alt="stop" (same as the legacy inline JSX) so the
+//     e2e specs and any accessibility-driven queries continue to work.
+//   - Transitioning the alerts.typology.outcome from "interdict" back to
+//     "none" (RESET_ALERTS on transaction boundary, per
+//     processor.reducer.tsx#ACTIONS.RESET_ALERTS) hides the image.
+//   - The component reads ONLY from ctx.alerts.eventFlow.outcome and
+//     ctx.alerts.typology.outcome (not adjudicator, not adjudicatorLights).
+
+import { render, screen } from "@testing-library/react"
+import React from "react"
+
+import { StopOverlay } from "../components/StopOverlay/StopOverlay"
+import ProcessorContext from "../store/processors/processor.context"
+import type { AdjudicatorOutcome, EventFlowOutcome, TypologyOutcome } from "../store/processors/processor.interface"
+
+function renderWithAlerts(
+  eventFlow: EventFlowOutcome,
+  typology: TypologyOutcome,
+  adjudicator: AdjudicatorOutcome = "none"
+) {
+  const value = {
+    alerts: {
+      eventFlow: { outcome: eventFlow },
+      typology: { outcome: typology },
+      adjudicator: { outcome: adjudicator },
+    },
+  } as unknown as React.ContextType<typeof ProcessorContext>
+
+  return render(
+    <ProcessorContext.Provider value={value}>
+      <StopOverlay />
+    </ProcessorContext.Provider>
+  )
+}
+
+describe("<StopOverlay /> truth table (#129)", () => {
+  it("hides STOP in the initial / reset state (eventFlow=none, typology=none)", () => {
+    renderWithAlerts("none", "none")
+    expect(screen.queryByAltText("stop")).not.toBeInTheDocument()
+  })
+
+  it("shows STOP when typology has interdicted (eventFlow=none, typology=interdict)", () => {
+    renderWithAlerts("none", "interdict")
+    expect(screen.getByAltText("stop")).toBeInTheDocument()
+  })
+
+  it("shows STOP when EFRuP has blocked (eventFlow=block, typology=none)", () => {
+    renderWithAlerts("block", "none")
+    expect(screen.getByAltText("stop")).toBeInTheDocument()
+  })
+
+  it("shows STOP when both EFRuP block and typology interdict are set", () => {
+    renderWithAlerts("block", "interdict")
+    expect(screen.getByAltText("stop")).toBeInTheDocument()
+  })
+
+  it("hides STOP when EFRuP has overridden (eventFlow=override, typology=none)", () => {
+    renderWithAlerts("override", "none")
+    expect(screen.queryByAltText("stop")).not.toBeInTheDocument()
+  })
+
+  it("hides STOP when EFRuP override overrides a typology interdiction (eventFlow=override, typology=interdict)", () => {
+    renderWithAlerts("override", "interdict")
+    expect(screen.queryByAltText("stop")).not.toBeInTheDocument()
+  })
+})
+
+describe("<StopOverlay /> decoupling from EVENT ADJUDICATOR (#129)", () => {
+  // ALRT/NALT from the adjudicator must NOT influence the overlay. The EA
+  // sub-panel light/pill is the only visual surface for adjudicator state.
+  it.each<AdjudicatorOutcome>(["none", "alrt", "nalt"])(
+    "ignores adjudicator outcome '%s' when eventFlow/typology say no STOP",
+    (adj) => {
+      renderWithAlerts("none", "none", adj)
+      expect(screen.queryByAltText("stop")).not.toBeInTheDocument()
+    }
+  )
+
+  it.each<AdjudicatorOutcome>(["none", "alrt", "nalt"])(
+    "ignores adjudicator outcome '%s' when typology has interdicted (STOP still visible)",
+    (adj) => {
+      renderWithAlerts("none", "interdict", adj)
+      expect(screen.getByAltText("stop")).toBeInTheDocument()
+    }
+  )
+
+  it.each<AdjudicatorOutcome>(["none", "alrt", "nalt"])(
+    "ignores adjudicator outcome '%s' when eventFlow has overridden (STOP still hidden)",
+    (adj) => {
+      renderWithAlerts("override", "interdict", adj)
+      expect(screen.queryByAltText("stop")).not.toBeInTheDocument()
+    }
+  )
+})
+
+describe("<StopOverlay /> transaction-boundary reset (#129)", () => {
+  // The alerts reducer's RESET_ALERTS action fires when entityCtx.currentMsgId
+  // changes, atomically resetting all three sub-panels back to "none". We
+  // simulate that here by re-rendering with the post-reset context value and
+  // asserting the overlay disappears, with no additional logic in the
+  // overlay itself.
+  it("hides STOP when alerts.typology.outcome transitions interdict -> none", () => {
+    const interdictValue = {
+      alerts: {
+        eventFlow: { outcome: "none" },
+        typology: { outcome: "interdict" },
+        adjudicator: { outcome: "alrt" },
+      },
+    } as unknown as React.ContextType<typeof ProcessorContext>
+    const resetValue = {
+      alerts: {
+        eventFlow: { outcome: "none" },
+        typology: { outcome: "none" },
+        adjudicator: { outcome: "none" },
+      },
+    } as unknown as React.ContextType<typeof ProcessorContext>
+
+    const { rerender } = render(
+      <ProcessorContext.Provider value={interdictValue}>
+        <StopOverlay />
+      </ProcessorContext.Provider>
+    )
+    expect(screen.getByAltText("stop")).toBeInTheDocument()
+
+    rerender(
+      <ProcessorContext.Provider value={resetValue}>
+        <StopOverlay />
+      </ProcessorContext.Provider>
+    )
+    expect(screen.queryByAltText("stop")).not.toBeInTheDocument()
+  })
+
+  it("hides STOP when alerts.eventFlow.outcome transitions block -> none", () => {
+    const blockValue = {
+      alerts: {
+        eventFlow: { outcome: "block" },
+        typology: { outcome: "none" },
+        adjudicator: { outcome: "none" },
+      },
+    } as unknown as React.ContextType<typeof ProcessorContext>
+    const resetValue = {
+      alerts: {
+        eventFlow: { outcome: "none" },
+        typology: { outcome: "none" },
+        adjudicator: { outcome: "none" },
+      },
+    } as unknown as React.ContextType<typeof ProcessorContext>
+
+    const { rerender } = render(
+      <ProcessorContext.Provider value={blockValue}>
+        <StopOverlay />
+      </ProcessorContext.Provider>
+    )
+    expect(screen.getByAltText("stop")).toBeInTheDocument()
+
+    rerender(
+      <ProcessorContext.Provider value={resetValue}>
+        <StopOverlay />
+      </ProcessorContext.Provider>
+    )
+    expect(screen.queryByAltText("stop")).not.toBeInTheDocument()
+  })
+})
+
+describe("<StopOverlay /> idempotency (#129)", () => {
+  // The alerts reducer already guarantees that repeated SET_TYPOLOGY_INTERDICTION
+  // dispatches are no-ops (verified at the reducer layer in
+  // __tests__/alerts.reducer.test.ts - case ACTIONS.SET_TYPOLOGY_INTERDICTION).
+  // The overlay rendering must therefore be stable across identical inputs -
+  // re-rendering with the same context value MUST NOT unmount/remount the
+  // image (which would cause flicker and re-trigger next/image LCP
+  // measurements).
+  it("does not unmount the STOP image when re-rendered with an unchanged interdiction state", () => {
+    const value = {
+      alerts: {
+        eventFlow: { outcome: "none" },
+        typology: { outcome: "interdict" },
+        adjudicator: { outcome: "none" },
+      },
+    } as unknown as React.ContextType<typeof ProcessorContext>
+
+    const { rerender } = render(
+      <ProcessorContext.Provider value={value}>
+        <StopOverlay />
+      </ProcessorContext.Provider>
+    )
+    const first = screen.getByAltText("stop")
+
+    rerender(
+      <ProcessorContext.Provider value={value}>
+        <StopOverlay />
+      </ProcessorContext.Provider>
+    )
+    const second = screen.getByAltText("stop")
+
+    // Same DOM node, not a re-mount.
+    expect(second).toBe(first)
+  })
+})

--- a/__tests__/processIndicator.test.tsx
+++ b/__tests__/processIndicator.test.tsx
@@ -1,0 +1,108 @@
+// ─── <ProcessIndicator /> tests (red phase, issue #129) ─────────────────────
+//
+// Spec re-derivation: the centre-lane dot trail no longer reads
+// `adjudicatorLights.stop` / `adjudicatorLights.efrup` (legacy slice). It
+// re-derives its colouring from the alerts slice via a single discriminated
+// `mode` prop computed by the parent (app/(demo)/page.tsx) using
+// `getIndicatorMode(eventFlow, typology)` from lib/stopOverlay.ts.
+//
+// Mode -> visual contract:
+//   mode="stop"      -> all 9 dots red                        (issue #129 rule)
+//   mode="override"  -> all 9 dots green                      (issue #129 rule)
+//   mode="idle"      -> animated rotating green dot if started, else all neutral
+//
+// This file deliberately does NOT exercise the old `stop` / `efrup` props -
+// those are being removed in the green phase.
+
+import { render } from "@testing-library/react"
+import React from "react"
+
+import { ProcessIndicator } from "../components/ProcessIndicator/ProcessIndicator"
+function countLightsByColour(): { r: number; g: number; n: number; y: number; b: number } {
+  // next/image renders <img alt=""> which testing-library classifies as
+  // role="presentation" (decorative), so getAllByRole("img") returns nothing.
+  // Query the DOM directly instead.
+  const imgs = Array.from(document.querySelectorAll("img")) as HTMLImageElement[]
+  const counts = { r: 0, g: 0, n: 0, y: 0, b: 0 }
+  for (const img of imgs) {
+    if (img.src.includes("red-light")) counts.r += 1
+    else if (img.src.includes("green-light")) counts.g += 1
+    else if (img.src.includes("neutral-light")) counts.n += 1
+    else if (img.src.includes("yellow-light")) counts.y += 1
+    else if (img.src.includes("blue-light")) counts.b += 1
+  }
+  return counts
+}
+
+describe("<ProcessIndicator /> mode='stop' (#129)", () => {
+  it("renders all 9 dots red regardless of `started`", () => {
+    render(<ProcessIndicator started={true} mode="stop" />)
+    const counts = countLightsByColour()
+    expect(counts.r).toBe(9)
+    expect(counts.g).toBe(0)
+    expect(counts.n).toBe(0)
+  })
+
+  it("still renders red when `started` is false (mode wins over animation)", () => {
+    render(<ProcessIndicator started={false} mode="stop" />)
+    const counts = countLightsByColour()
+    expect(counts.r).toBe(9)
+  })
+})
+
+describe("<ProcessIndicator /> mode='override' (#129)", () => {
+  it("renders all 9 dots green regardless of `started`", () => {
+    render(<ProcessIndicator started={true} mode="override" />)
+    const counts = countLightsByColour()
+    expect(counts.g).toBe(9)
+    expect(counts.r).toBe(0)
+    expect(counts.n).toBe(0)
+  })
+
+  it("renders all 9 dots green even when `started` is false (override is an explicit verdict, not an animation state)", () => {
+    render(<ProcessIndicator started={false} mode="override" />)
+    const counts = countLightsByColour()
+    expect(counts.g).toBe(9)
+  })
+})
+
+describe("<ProcessIndicator /> mode='idle' (#129)", () => {
+  // These two cases happen to pass against the current (pre-green-phase)
+  // component because the existing logic for `!stop` / `!started` overlaps
+  // with the new `mode='idle'` contract. They are NOT compatibility back-
+  // doors - they pin the contract going forward, so the green-phase
+  // rewrite cannot regress idle behaviour. The 5 failing tests in the
+  // mode='stop' / mode='override' / prop-contract blocks are what proves
+  // the implementation is gap-driven, not the absence of these two.
+  it("renders 9 dots when `started` is true (animated trail; exact rotation tick is timing-dependent)", () => {
+    render(<ProcessIndicator started={true} mode="idle" />)
+    const imgs = document.querySelectorAll("img")
+    expect(imgs.length).toBe(9)
+    // No dot is red or override-green in idle mode.
+    const counts = countLightsByColour()
+    expect(counts.r).toBe(0)
+  })
+
+  it("renders 9 neutral dots when `started` is false (pre-transaction baseline)", () => {
+    render(<ProcessIndicator started={false} mode="idle" />)
+    const counts = countLightsByColour()
+    expect(counts.n).toBe(9)
+    expect(counts.r).toBe(0)
+    expect(counts.g).toBe(0)
+  })
+})
+
+describe("<ProcessIndicator /> prop contract (#129)", () => {
+  // The legacy `stop` and `efrup` props are removed in this PR. TypeScript
+  // is the primary guard, but adding a runtime check here catches the case
+  // where a stale caller passes them as `any` (e.g. via spread) without
+  // the type system flagging it. The component must IGNORE them and key
+  // its render entirely on `mode`.
+  it("ignores any legacy `stop` / `efrup` props if passed and keys render on `mode` alone", () => {
+    // @ts-expect-error - legacy props removed from the interface
+    render(<ProcessIndicator started={true} mode="idle" stop={true} efrup="block" />)
+    const counts = countLightsByColour()
+    // mode='idle' wins - no red dots even though stop=true was passed.
+    expect(counts.r).toBe(0)
+  })
+})

--- a/__tests__/stopOverlay.test.ts
+++ b/__tests__/stopOverlay.test.ts
@@ -1,0 +1,101 @@
+// ─── STOP-sign overlay derivation tests (red phase, issue #129) ─────────────
+//
+// The STOP overlay (the central red octagonal "hand" image rendered between
+// the debtor and creditor phones on the demo home page) is being re-based
+// from the legacy `adjudicatorLights.stop` / `adjudicatorLights.efrup` slice
+// onto the new ALERTS-panel slice introduced in #124.
+//
+// Spec: issue #129 - "fix: re-base STOP overlay on alerts slice".
+//
+// Inputs (both already exposed on `state.alerts`):
+//   - alerts.eventFlow.outcome   ∈ { "none", "block", "override" }
+//   - alerts.typology.outcome    ∈ { "none", "interdict" }
+//
+// alerts.adjudicator.outcome is INTENTIONALLY not an input - ALRT only
+// generates an alert for investigation, it does NOT trigger a stop.
+//
+// Truth table (#129):
+//   eventFlow="none"     typology="none"      -> hide
+//   eventFlow="none"     typology="interdict" -> show
+//   eventFlow="block"    typology="none"      -> show
+//   eventFlow="block"    typology="interdict" -> show
+//   eventFlow="override" typology="none"      -> hide  (override permits flow)
+//   eventFlow="override" typology="interdict" -> hide  (override wins)
+//
+// Equivalent boolean:
+//   SHOW  ⇔  eventFlow !== "override"
+//            ∧ (eventFlow === "block" ∨ typology === "interdict")
+//
+// Companion derivation for the centre-lane dot trail (`ProcessIndicator`):
+//   eventFlow === "override"     -> "override"   (all-green dots)
+//   showStop                     -> "stop"       (all-red dots)
+//   otherwise                    -> "idle"       (animated grey dots if started)
+
+import { getIndicatorMode, shouldShowStop } from "../lib/stopOverlay"
+import type { EventFlowOutcome, TypologyOutcome } from "../store/processors/processor.interface"
+
+describe("shouldShowStop (#129 truth table)", () => {
+  // Drive the table verbatim so a future spec amendment can be diff-reviewed
+  // against this list. The `expected` column matches the table in the issue
+  // body 1:1.
+  const cases: Array<[EventFlowOutcome, TypologyOutcome, boolean]> = [
+    ["none", "none", false],
+    ["none", "interdict", true],
+    ["block", "none", true],
+    ["block", "interdict", true],
+    ["override", "none", false],
+    ["override", "interdict", false],
+  ]
+
+  it.each(cases)("eventFlow=%s typology=%s -> %s", (eventFlow, typology, expected) => {
+    expect(shouldShowStop(eventFlow, typology)).toBe(expected)
+  })
+
+  it("returns the SAME value for repeated identical inputs (pure function, no hidden latch)", () => {
+    expect(shouldShowStop("none", "interdict")).toBe(true)
+    expect(shouldShowStop("none", "interdict")).toBe(true)
+    expect(shouldShowStop("none", "interdict")).toBe(true)
+  })
+
+  it("never reads alerts.adjudicator.outcome (decoupled from EA per #129)", () => {
+    // The function signature accepts exactly two args. If a future
+    // refactor accidentally adds an adjudicator parameter, callers wired up
+    // through the truth table would silently start coupling EA into the
+    // STOP decision. Lock the arity so that regression is caught here.
+    expect(shouldShowStop.length).toBe(2)
+  })
+})
+
+describe("getIndicatorMode (#129 dot-trail derivation)", () => {
+  it("returns 'override' when eventFlow is 'override' (regardless of typology - override wins)", () => {
+    expect(getIndicatorMode("override", "none")).toBe("override")
+    expect(getIndicatorMode("override", "interdict")).toBe("override")
+  })
+
+  it("returns 'stop' when eventFlow is 'block' (regardless of typology)", () => {
+    expect(getIndicatorMode("block", "none")).toBe("stop")
+    expect(getIndicatorMode("block", "interdict")).toBe("stop")
+  })
+
+  it("returns 'stop' when typology has interdicted and eventFlow has not overridden", () => {
+    expect(getIndicatorMode("none", "interdict")).toBe("stop")
+  })
+
+  it("returns 'idle' in the pre-decision / reset state", () => {
+    expect(getIndicatorMode("none", "none")).toBe("idle")
+  })
+
+  it("is consistent with shouldShowStop (mode='stop' ⇔ showStop=true)", () => {
+    const all: Array<[EventFlowOutcome, TypologyOutcome]> = [
+      ["none", "none"],
+      ["none", "interdict"],
+      ["block", "none"],
+      ["block", "interdict"],
+      ["override", "none"],
+      ["override", "interdict"],
+    ]
+    for (const [ef, tp] of all) {
+      expect(getIndicatorMode(ef, tp) === "stop").toBe(shouldShowStop(ef, tp))
+    }
+  })
+})

--- a/app/(demo)/page.tsx
+++ b/app/(demo)/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { DragDropContext } from "@hello-pangea/dnd"
-import Image from "next/image"
 import React, { useContext, useEffect, useState } from "react"
 import io from "socket.io-client"
 import { AlertsPanel } from "components/AlertsPanel/AlertsPanel"
@@ -16,7 +15,9 @@ import DebtorModal from "components/Modal/Modal"
 import { ProcessIndicator } from "components/ProcessIndicator/ProcessIndicator"
 import RuleResult from "components/RuleResults/RuleResults"
 import { StatusIndicator } from "components/StatusIndicator/StatusIndicator"
+import { StopOverlay } from "components/StopOverlay/StopOverlay"
 import TypeResult from "components/TypologyResults/TypologyResults"
+import { getIndicatorMode } from "lib/stopOverlay"
 import EntityContext from "store/entities/entity.context"
 import { CdtrEntity, Entity } from "store/entities/entity.interface"
 import ProcessorContext from "store/processors/processor.context"
@@ -402,42 +403,9 @@ const Web = () => {
               <div className="relative col-span-4 flex items-center justify-between px-5">
                 <ProcessIndicator
                   started={started}
-                  stop={processCtx.adjudicatorLights.stop}
-                  efrup={processCtx.adjudicatorLights.efrup}
+                  mode={getIndicatorMode(processCtx.alerts.eventFlow.outcome, processCtx.alerts.typology.outcome)}
                 />
-                {processCtx.adjudicatorLights.efrup === "block" ? (
-                  <Image
-                    src="/stop.png"
-                    width="250"
-                    height="250"
-                    className="absolute inset-0 m-auto"
-                    style={{
-                      position: "absolute",
-                      zIndex: 1,
-                      minWidth: "280px",
-                    }}
-                    alt="stop"
-                    priority={true}
-                  />
-                ) : (
-                  processCtx.adjudicatorLights.stop &&
-                  processCtx.adjudicatorLights.efrup !== "override" && (
-                    <Image
-                      src="/stop.png"
-                      width="250"
-                      height="250"
-                      className="absolute inset-0 m-auto"
-                      style={{
-                        position: "absolute",
-                        zIndex: 1,
-                        // maxWidth: "280px",
-                        minWidth: "280px",
-                      }}
-                      alt="stop"
-                      priority={true}
-                    />
-                  )
-                )}
+                <StopOverlay />
               </div>
               <div className="col-span-4">
                 <DebtorDevice

--- a/components/ProcessIndicator/ProcessIndicator.tsx
+++ b/components/ProcessIndicator/ProcessIndicator.tsx
@@ -1,12 +1,24 @@
 import React, { useEffect, useState } from "react"
 import { StatusIndicator } from "../StatusIndicator/StatusIndicator"
 
+/**
+ * Centre-lane dot trail rendered between the debtor and creditor phone
+ * cards. Re-derived from the ALERTS slice in #129:
+ *
+ *   mode="stop"      -> all 9 dots red          (eventFlow=block OR typology=interdict, no override)
+ *   mode="override"  -> all 9 dots green        (EFRuP override permits flow, wins over interdict)
+ *   mode="idle"      -> animated rotating green dot if `started`,
+ *                       else 9 neutral dots     (pre-transaction / awaiting verdict)
+ *
+ * Mode is computed by the parent via `getIndicatorMode(eventFlow, typology)`
+ * from `lib/stopOverlay.ts`. The legacy `stop` / `efrup` props have been
+ * removed - the component now keys its render entirely on `mode`.
+ */
 interface Props {
   started: boolean
-  stop?: boolean
-  efrup?: string
+  mode: "idle" | "stop" | "override"
 }
-export function ProcessIndicator({ started, stop, efrup }: Props) {
+export function ProcessIndicator({ started, mode }: Props) {
   const [progress, setProgress] = useState<number | null>(null)
 
   useEffect(() => {
@@ -28,7 +40,41 @@ export function ProcessIndicator({ started, stop, efrup }: Props) {
       setProgress(null)
     }
   }, [progress, started])
-  return !stop ? (
+
+  if (mode === "stop") {
+    return (
+      <>
+        <StatusIndicator colour={"r"} />
+        <StatusIndicator colour={"r"} />
+        <StatusIndicator colour={"r"} />
+        <StatusIndicator colour={"r"} />
+        <StatusIndicator colour={"r"} />
+        <StatusIndicator colour={"r"} />
+        <StatusIndicator colour={"r"} />
+        <StatusIndicator colour={"r"} />
+        <StatusIndicator colour={"r"} />
+      </>
+    )
+  }
+
+  if (mode === "override") {
+    return (
+      <>
+        <StatusIndicator colour={"g"} />
+        <StatusIndicator colour={"g"} />
+        <StatusIndicator colour={"g"} />
+        <StatusIndicator colour={"g"} />
+        <StatusIndicator colour={"g"} />
+        <StatusIndicator colour={"g"} />
+        <StatusIndicator colour={"g"} />
+        <StatusIndicator colour={"g"} />
+        <StatusIndicator colour={"g"} />
+      </>
+    )
+  }
+
+  // mode === "idle"
+  return (
     <>
       <StatusIndicator colour={progress === 0 ? "g" : "n"} />
       <StatusIndicator colour={progress === 1 ? "g" : "n"} />
@@ -39,30 +85,6 @@ export function ProcessIndicator({ started, stop, efrup }: Props) {
       <StatusIndicator colour={progress === 6 ? "g" : "n"} />
       <StatusIndicator colour={progress === 7 ? "g" : "n"} />
       <StatusIndicator colour={progress === 8 ? "g" : "n"} />
-    </>
-  ) : efrup === "override" ? (
-    <>
-      <StatusIndicator colour={"g"} />
-      <StatusIndicator colour={"g"} />
-      <StatusIndicator colour={"g"} />
-      <StatusIndicator colour={"g"} />
-      <StatusIndicator colour={"g"} />
-      <StatusIndicator colour={"g"} />
-      <StatusIndicator colour={"g"} />
-      <StatusIndicator colour={"g"} />
-      <StatusIndicator colour={"g"} />
-    </>
-  ) : (
-    <>
-      <StatusIndicator colour={"r"} />
-      <StatusIndicator colour={"r"} />
-      <StatusIndicator colour={"r"} />
-      <StatusIndicator colour={"r"} />
-      <StatusIndicator colour={"r"} />
-      <StatusIndicator colour={"r"} />
-      <StatusIndicator colour={"r"} />
-      <StatusIndicator colour={"r"} />
-      <StatusIndicator colour={"r"} />
     </>
   )
 }

--- a/components/StopOverlay/StopOverlay.tsx
+++ b/components/StopOverlay/StopOverlay.tsx
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+import Image from "next/image"
+import React, { useContext } from "react"
+import ProcessorContext from "store/processors/processor.context"
+
+import { shouldShowStop } from "../../lib/stopOverlay"
+
+/**
+ * Central STOP-sign overlay rendered on top of the centre-lane dot trail
+ * (between the debtor and creditor phone cards) on the demo home page.
+ *
+ * Reads exclusively from the ALERTS slice introduced in #124 - specifically
+ * `alerts.eventFlow.outcome` and `alerts.typology.outcome`. The EVENT
+ * ADJUDICATOR outcome (`alerts.adjudicator.outcome`) is INTENTIONALLY NOT
+ * an input: ALRT only generates an alert for investigation, it does NOT
+ * trigger a stop. The legacy reads of `adjudicatorLights.stop` /
+ * `adjudicatorLights.efrup` have been removed.
+ *
+ * Spec: tazama-lf/tazama-demo#129 truth table:
+ *
+ *   eventFlow="none"     typology="none"      -> hidden
+ *   eventFlow="none"     typology="interdict" -> visible
+ *   eventFlow="block"    typology="none"      -> visible
+ *   eventFlow="block"    typology="interdict" -> visible
+ *   eventFlow="override" typology="none"      -> hidden
+ *   eventFlow="override" typology="interdict" -> hidden (override wins)
+ *
+ * Transaction-boundary reset is inherited from the existing RESET_ALERTS
+ * effect in the alerts provider (gated on `entityCtx.currentMsgId`), so the
+ * overlay needs no per-component reset logic. Idempotency on repeated
+ * SET_TYPOLOGY_INTERDICTION dispatches is inherited from the reducer's
+ * terminal-state design - the rendered DOM node is stable across identical
+ * inputs (no remount, no flicker, no next/image LCP re-measurement).
+ *
+ * The image carries `alt="stop"` so the existing Playwright e2e specs and
+ * accessibility queries continue to work.
+ */
+export function StopOverlay() {
+  const ctx = useContext(ProcessorContext)
+  const showStop = shouldShowStop(ctx.alerts.eventFlow.outcome, ctx.alerts.typology.outcome)
+
+  if (!showStop) return null
+
+  return (
+    <Image
+      src="/stop.png"
+      width={250}
+      height={250}
+      className="absolute inset-0 m-auto"
+      style={{
+        position: "absolute",
+        zIndex: 1,
+        minWidth: "280px",
+      }}
+      alt="stop"
+      priority={true}
+    />
+  )
+}
+
+export default StopOverlay

--- a/lib/stopOverlay.ts
+++ b/lib/stopOverlay.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Pure derivations for the centre-lane STOP overlay and ProcessIndicator
+// dot-trail, both keyed on the new ALERTS slice introduced in #124.
+//
+// Spec: tazama-lf/tazama-demo#129
+//
+// Inputs (both already exposed on `state.alerts`):
+//   - eventFlow ∈ { "none", "block", "override" }
+//   - typology  ∈ { "none", "interdict" }
+//
+// alerts.adjudicator.outcome is INTENTIONALLY not an input - ALRT only
+// generates an alert for investigation, it does NOT trigger a stop.
+// Idempotency of repeated typology interdictions is inherited from the
+// alerts reducer's terminal-state design (see
+// __tests__/alerts.reducer.test.ts case ACTIONS.SET_TYPOLOGY_INTERDICTION).
+
+import type { EventFlowOutcome, TypologyOutcome } from "../store/processors/processor.interface"
+
+/**
+ * Returns true iff the central STOP overlay should be rendered.
+ *
+ * Boolean form of the #129 truth table:
+ *   SHOW ⇔ eventFlow !== "override"
+ *          ∧ (eventFlow === "block" ∨ typology === "interdict")
+ *
+ * Arity is locked at 2 by `shouldShowStop.length === 2` in the test suite
+ * so a future refactor cannot silently re-introduce a dependency on
+ * `alerts.adjudicator.outcome`.
+ */
+export function shouldShowStop(eventFlow: EventFlowOutcome, typology: TypologyOutcome): boolean {
+  if (eventFlow === "override") return false
+  return eventFlow === "block" || typology === "interdict"
+}
+
+/**
+ * Visual mode for the centre-lane dot trail (`<ProcessIndicator />`).
+ *
+ *   "override" -> all-green dots          (eventFlow="override" wins over typology)
+ *   "stop"     -> all-red dots            (equivalent to shouldShowStop === true)
+ *   "idle"     -> animated grey trail (when started) or all-neutral (when not)
+ *
+ * Co-derived with shouldShowStop: `mode === "stop" ⇔ shouldShowStop === true`
+ * (test in stopOverlay.test.ts pins this invariant).
+ */
+export function getIndicatorMode(eventFlow: EventFlowOutcome, typology: TypologyOutcome): "idle" | "stop" | "override" {
+  if (eventFlow === "override") return "override"
+  if (shouldShowStop(eventFlow, typology)) return "stop"
+  return "idle"
+}


### PR DESCRIPTION
# Re-base STOP overlay on alerts slice (decouple from legacy adjudicatorLights)

Closes #129.

## Problem

The central STOP overlay and the centre-lane dot trail
(`<ProcessIndicator />`) were both keyed on `processCtx.adjudicatorLights.stop`
and `processCtx.adjudicatorLights.efrup` - the **legacy** TADPROC slice. The
alerts slice introduced in #124 is now the canonical source of truth for
evaluation outcomes, and the legacy slice contains EVENT ADJUDICATOR signal
that should **not** drive a stop: ALRT only generates an alert for
investigation, it does not trigger a stop.

Stops should only ever be triggered by:

1. The first interdiction from typology (idempotent thereafter), or
2. An outright `block` from EFRuP.

An EFRuP `override` always wins (permits the transaction even if typology
asked for an interdiction).

## Truth table (#129)

| `eventFlow.outcome` | `typology.outcome` | STOP? | `ProcessIndicator` mode |
|---------------------|--------------------|-------|-------------------------|
| `none`              | `none`             | hidden | `idle`                 |
| `none`              | `interdict`        | **visible** | `stop`            |
| `block`             | `none`             | **visible** | `stop`            |
| `block`             | `interdict`        | **visible** | `stop`            |
| `override`          | `none`             | hidden | `override`             |
| `override`          | `interdict`        | hidden (override wins) | `override` |

Reduced boolean: `SHOW <=> eventFlow != "override" AND (eventFlow == "block" OR typology == "interdict")`.

`alerts.adjudicator.outcome` is **intentionally not** an input - the test
suite locks `shouldShowStop.length === 2` so a future refactor cannot
silently re-introduce EA coupling.

## Changes

Five commits, in red-tests-first order:

1. **`test:`** Add 3 failing test suites pinning the new contract
   (truth table, EA decoupling, transaction-boundary reset,
   idempotency, `ProcessIndicator` `mode` prop).
2. **`feat:`** Add `lib/stopOverlay.ts` exporting `shouldShowStop` and
   `getIndicatorMode` - pure functions, no React dependency.
3. **`feat:`** Add `<StopOverlay />` component that reads from
   `ProcessorContext.alerts` and renders the `/stop.png` image with the
   same positioning style as the legacy inline JSX.
4. **`refactor:`** Re-base `<ProcessIndicator />` on a single
   `mode: "idle" | "stop" | "override"` prop. Legacy `stop` / `efrup`
   props removed from the interface.
5. **`feat:`** Wire both new components into `app/(demo)/page.tsx`,
   replacing the 30-line two-branch `<Image>` ladder with `<StopOverlay />`
   and the legacy `ProcessIndicator` props with
   `mode={getIndicatorMode(...)}`. Also drops the now-unused
   `import Image from "next/image"`.

## Out of scope

The reducer / `utils/adjudicatorUtils.ts` still write to
`adjudicatorLights.stop` and `adjudicatorLights.efrup`. No production
code reads them after this PR, but ripping them out requires touching
the EA socket handler and the legacy `TADPROC` type - that can be done
in a follow-up.

## Verification

- `npm test` - **575 passed**, 37 suites, 0 failures (was 544 pre-PR; +31 new tests)
- `npm run lint` - no new warnings introduced
- `npm run build` - clean production build

## Red-phase evidence

Before any production code was written, the three test suites failed for the right reasons:

- `__tests__/stopOverlay.test.ts` - suite failed to load (missing `lib/stopOverlay`)
- `__tests__/StopOverlay.test.tsx` - suite failed to load (missing component)
- `__tests__/processIndicator.test.tsx` - 5 failed / 2 passed (the 2 passing
  `mode='idle'` cases coincide with existing behaviour and serve as
  forward-pinning checks; they are documented inline)

Sub-agent reviewed the failing tests, confirmed coverage of the spec, and
flagged the absence of a page-level wiring test - deferred by maintainer
agreement on the grounds that this is a once-off value and regressions
will be caught by manual smoke tests and the existing component-level
suites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented STOP overlay that displays based on transaction event flow and typology outcomes.
  * Refactored process indicator to use mode-driven states (idle, stop, override) for visual feedback.

* **Tests**
  * Added comprehensive test coverage for STOP overlay visibility and behavior.
  * Added tests verifying process indicator modes across transaction states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->