### PR TITLE
build: change default port from 3001 to 3011 to avoid DEAPI conflict

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 FUNCTION_NAME=tazama-demo
 NODE_ENV=development
-PORT=3001
+PORT=3011
 
 # Next.js
 NEXT_TELEMETRY_DISABLED=1
@@ -26,8 +26,8 @@ TP_INTERDICTION_DESTINATION=global
 
 # Client-side config (safe - no credentials)
 # Set to the public URL of this app (default works for local development)
-NEXT_PUBLIC_URL=http://localhost:3001
-NEXT_PUBLIC_WS_URL=http://localhost:3001
+NEXT_PUBLIC_URL=http://localhost:3011
+NEXT_PUBLIC_WS_URL=http://localhost:3011
 
 # Authentication
 # Set AUTHENTICATED=true and uncomment the lines below to enable login via the
@@ -39,10 +39,10 @@ AUTHENTICATED=false
 #AUTH_SERVICE_URL=http://localhost:3020
 # Canonical public URL of this app. Auth.js v5 uses this to build absolute
 # post-login redirect URLs. Strongly recommended when AUTHENTICATED=true -
-# this app listens on PORT=3001, not Auth.js's default of 3000, so without
+# this app listens on PORT=3011, not Auth.js's default of 3000, so without
 # AUTH_URL the post-login redirect can target the wrong origin
 # (e.g. http://localhost:3000). Set to the same value as NEXT_PUBLIC_URL.
-#AUTH_URL=http://localhost:3001
+#AUTH_URL=http://localhost:3011
 #NEXTAUTH_SECRET=  # Required when AUTHENTICATED=true - generate: openssl rand -base64 32
 
 # Test mode (Playwright e2e without a live stack)

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM node:22-bookworm-slim AS base
 WORKDIR /app
 COPY package*.json ./
-EXPOSE 3001
+EXPOSE 3011
 
 FROM base AS builder
 WORKDIR /app
@@ -30,9 +30,9 @@ ENV GIT_SHA=${GIT_SHA}
 ENV BUILD_TIME=${BUILD_TIME}
 
 ENV NODE_ENV=production
-ENV PORT="3001"
-ENV NEXT_PUBLIC_URL="http://localhost:3001"
-ENV NEXT_PUBLIC_WS_URL="http://localhost:3001"
+ENV PORT="3011"
+ENV NEXT_PUBLIC_URL="http://localhost:3011"
+ENV NEXT_PUBLIC_WS_URL="http://localhost:3011"
 
 # Server-side configuration (never exposed to browser).
 # Required vars (NATS_SERVER_URL, ADMIN_SERVICE_URL, TMS_SERVER_URL) must be
@@ -65,6 +65,6 @@ COPY --from=builder /app/lib ./lib
 # trigger restart loops. Orchestrators (k8s, docker swarm) should additionally
 # probe /api/ready for traffic-readiness; see deployment.yaml.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD node -e "fetch('http://localhost:'+ (process.env.PORT||3001) +'/api/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+  CMD node -e "fetch('http://localhost:'+ (process.env.PORT||3011) +'/api/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
 CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ cp .env.template .env
 
 | Variable | Default | Purpose | Example |
 |---|---|---|---|
-| `NEXT_PUBLIC_URL` | `http://localhost:3001` | Public base URL of this app. Used for OAuth redirect URIs and absolute URL construction. Change this when running behind a reverse proxy or on a non-default port. | `http://demo.example.com` |
-| `NEXT_PUBLIC_WS_URL` | `http://localhost:3001` | WebSocket server URL. The custom Node server serves Socket.IO on this address. Must be reachable from the browser. | `http://demo.example.com` |
+| `NEXT_PUBLIC_URL` | `http://localhost:3011` | Public base URL of this app. Used for OAuth redirect URIs and absolute URL construction. Change this when running behind a reverse proxy or on a non-default port. | `http://demo.example.com` |
+| `NEXT_PUBLIC_WS_URL` | `http://localhost:3011` | WebSocket server URL. The custom Node server serves Socket.IO on this address. Must be reachable from the browser. | `http://demo.example.com` |
 
 **Authentication (disabled by default):**
 
@@ -117,7 +117,7 @@ cp .env.template .env
 |---|---|---|---|
 | `AUTHENTICATED` | `false` | Set to `true` to require login via the Tazama auth-service (which federates to Keycloak). When `false`, all other auth variables are ignored. | `true` |
 | `AUTH_SERVICE_URL` | _(none)_ | Base URL of the Tazama [auth-service](https://github.com/tazama-lf/auth-service). The demo POSTs credentials to `${AUTH_SERVICE_URL}/v1/auth/login` and receives a Tazama JWT - this is **not** a direct Keycloak realm URL. Required when `AUTHENTICATED=true`. | `http://auth-service.example.com:3020` |
-| `AUTH_URL` | _(none)_ | Canonical public URL of this app. Auth.js v5 uses this to build absolute post-login redirect URLs. **Strongly recommended when `AUTHENTICATED=true`:** this app listens on port `3001`, not Auth.js's default port `3000`, so without `AUTH_URL` (or `NEXTAUTH_URL`) Auth.js's host-header fallback can redirect the user to `http://localhost:3000` after login. Set to the same value as `NEXT_PUBLIC_URL`. | `http://localhost:3001` |
+| `AUTH_URL` | _(none)_ | Canonical public URL of this app. Auth.js v5 uses this to build absolute post-login redirect URLs. **Strongly recommended when `AUTHENTICATED=true`:** this app listens on port `3011`, not Auth.js's default port `3000`, so without `AUTH_URL` (or `NEXTAUTH_URL`) Auth.js's host-header fallback can redirect the user to `http://localhost:3000` after login. Set to the same value as `NEXT_PUBLIC_URL`. | `http://localhost:3011` |
 | `NEXTAUTH_SECRET` | _(none)_ | Secret used by Auth.js v5 to encrypt the browser session cookie that wraps the Tazama JWT. Local to this app - never sent to auth-service or downstream Tazama services. Required when `AUTHENTICATED=true`. Generate with: `openssl rand -base64 32` | _(generated value)_ |
 
 **Condition type dropdowns (optional overrides):**
@@ -134,7 +134,7 @@ cp .env.template .env
 npm run dev
 ```
 
-6. Open [http://localhost:3001](http://localhost:3001) with your browser to see the result.
+6. Open [http://localhost:3011](http://localhost:3011) with your browser to see the result.
 
 <a><div align="right">[Top](#table-of-contents)</div></a>
 
@@ -276,7 +276,7 @@ If the build fails run the following script to revert changes made to the `docke
             - /app/node_modules
             - /app/.next
         ports:
-          - "3001:3001"
+          - "3011:3011"
         restart: always
         networks:
           - network1
@@ -337,7 +337,7 @@ services:
   tazama-demo:
     image: tazamaorg/tazama-demo:${TAZAMA_VERSION}
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:3001/api/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3011/api/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/__tests__/alerts.provider.test.tsx
+++ b/__tests__/alerts.provider.test.tsx
@@ -25,7 +25,7 @@
 //     without removing pre-existing entries (G1a, §6.2, scope-out #123)
 
 process.env.SKIP_ENV_VALIDATION = "1"
-process.env.NEXT_PUBLIC_WS_URL = "http://localhost:3001"
+process.env.NEXT_PUBLIC_WS_URL = "http://localhost:3011"
 
 // ─── Mocks (hoisted by Jest before imports) ──────────────────────────────────
 //

--- a/__tests__/entity.provider.test.tsx
+++ b/__tests__/entity.provider.test.tsx
@@ -3,7 +3,7 @@
  */
 // SPDX-License-Identifier: Apache-2.0
 process.env.SKIP_ENV_VALIDATION = "1"
-process.env.NEXT_PUBLIC_WS_URL = "http://localhost:3001"
+process.env.NEXT_PUBLIC_WS_URL = "http://localhost:3011"
 
 // ─── Mocks (hoisted by Jest before imports) ──────────────────────────────────
 
@@ -108,7 +108,7 @@ const UI_CONFIG_FIXTURE = {
   pgUser: "dbuser",
   pgPassword: "dbpass",
   pgDatabase: "tazama",
-  wsIpAddress: "http://localhost:3001",
+  wsIpAddress: "http://localhost:3011",
   adminServiceUrl: "",
   conditionTypes: "non-overridable-block,overridable-block",
   eventTypes: "pacs.008.001.10,pacs.002.001.12",

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -55,7 +55,7 @@ function mkRequest({
   search = "",
   auth = null as unknown,
 }: { path?: string; search?: string; auth?: unknown } = {}) {
-  const url = `http://localhost:3001${path}${search}`
+  const url = `http://localhost:3011${path}${search}`
   return { auth, url, nextUrl: new URL(url) }
 }
 
@@ -92,7 +92,7 @@ describe("middleware - AUTHENTICATED=true", () => {
     const middleware = loadMiddleware()
     const res = middleware(mkRequest({ path: "/dashboard" })) as { kind: string; url: string }
     expect(res.kind).toBe("redirect")
-    expect(res.url).toBe("http://localhost:3001/login?callbackUrl=%2Fdashboard")
+    expect(res.url).toBe("http://localhost:3011/login?callbackUrl=%2Fdashboard")
   })
 
   it("preserves the query string when propagating callbackUrl", () => {
@@ -102,7 +102,7 @@ describe("middleware - AUTHENTICATED=true", () => {
       url: string
     }
     expect(res.kind).toBe("redirect")
-    expect(res.url).toBe("http://localhost:3001/login?callbackUrl=%2Freports%2Fxyz%3Ftab%3Dsummary%26page%3D2")
+    expect(res.url).toBe("http://localhost:3011/login?callbackUrl=%2Freports%2Fxyz%3Ftab%3Dsummary%26page%3D2")
   })
 
   it("lets /login through without a redirect (prevents infinite loop)", () => {

--- a/__tests__/processor.provider.test.tsx
+++ b/__tests__/processor.provider.test.tsx
@@ -3,7 +3,7 @@
  */
 // SPDX-License-Identifier: Apache-2.0
 process.env.SKIP_ENV_VALIDATION = "1"
-process.env.NEXT_PUBLIC_WS_URL = "http://localhost:3001"
+process.env.NEXT_PUBLIC_WS_URL = "http://localhost:3011"
 
 // ─── Mocks (hoisted by Jest before imports) ──────────────────────────────────
 

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -11,4 +11,4 @@ services:
         - /app/node_modules
         - /app/.next
     ports:
-      - "3001:3001"
+      - "3011:3011"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://127.0.0.1:3001",
+    baseURL: "http://127.0.0.1:3011",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -33,13 +33,13 @@ export default defineConfig({
   /* Start the dev server before running tests */
   webServer: {
     command: "node server.js",
-    url: "http://127.0.0.1:3001",
+    url: "http://127.0.0.1:3011",
     reuseExistingServer: !process.env.CI,
     env: {
       SKIP_ENV_VALIDATION: "1",
       AUTHENTICATED: "false",
       TEST_MODE: "true",
-      PORT: "3001",
+      PORT: "3011",
       NODE_ENV: "development",
       NEXTAUTH_SECRET: "playwright-test-secret",
     },


### PR DESCRIPTION
## Summary

Change the demo's default port from `3001` to `3011` to avoid a collision with the DEAPI (Data Extraction API), which also listens on `3001` in dev environments.

This is a mechanical, additive-only change with no behaviour difference - the value is still entirely overridable via the `PORT` environment variable. `server.js` reads `process.env.PORT` with no hard-coded fallback, so it picks up the new default automatically from `.env.template` / Dockerfile `ENV`.

## Files changed (9)

**Runtime configuration**
- `.env.template` - `PORT`, `NEXT_PUBLIC_URL`, `NEXT_PUBLIC_WS_URL`, the `AUTH_URL` example, and the Auth.js host-header comment
- `Dockerfile` - `EXPOSE`, three `ENV` lines, and the HEALTHCHECK URL fallback (`process.env.PORT || 3011`)
- `docker-compose.production.yml` - host:container port mapping
- `playwright.config.ts` - `baseURL`, `webServer.url`, `webServer.env.PORT`

**Tests** (literal URLs - no env wiring in scope)
- `__tests__/middleware.test.ts` - 3 hard-coded callback URLs
- `__tests__/processor.provider.test.tsx` - `NEXT_PUBLIC_WS_URL` test setup
- `__tests__/alerts.provider.test.tsx` - `NEXT_PUBLIC_WS_URL` test setup
- `__tests__/entity.provider.test.tsx` - `NEXT_PUBLIC_WS_URL` test setup + `UI_CONFIG_FIXTURE.wsIpAddress`

**Docs**
- `README.md` - env-var table defaults, "Open http://localhost" link, docker compose port mapping example, healthcheck example, Auth.js port comparison

Net diff: 27 insertions / 27 deletions.

## Test summary

Full suite: **643 / 643 passing** (43 suites). Lint warnings are pre-existing in unrelated files (`TypologyResults`, etc.) - none introduced by this change. Pre-push hook ran the full suite on push.

## Out of scope

There is a pre-existing mismatch between `Dockerfile`'s `ENV PORT` and `deployment.yaml`'s `containerPort: 8080` / `service.yaml`'s `targetPort: 8080`. That K8s manifest is unrelated to this conflict-avoidance change and is left alone here. Worth a separate housekeeping pass.

## Breaking changes

None for default-config users. Anyone who has hard-coded `3001` in their own `.env`, reverse proxy, or external scripts will need to update to `3011` (or set `PORT=3001` explicitly to keep the old value).
