### PR TITLE
fix(ui): force dynamic rendering of (demo) layout so auth-gated header renders (#139)

### DIFF
--- a/__tests__/demo-layout.dynamic.test.ts
+++ b/__tests__/demo-layout.dynamic.test.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// ─── Mocks (hoisted by Jest before imports) ──────────────────────────────────
+// The (demo) layout pulls in auth, the auth-lib, and the React context
+// providers at module scope. None of that is relevant to the route-segment
+// config we are asserting, so stub them out to keep the test isolated and
+// side-effect free.
+jest.mock("lib/auth", () => ({ auth: jest.fn() }))
+jest.mock("@tazama-lf/auth-lib", () => ({ extractTenant: jest.fn() }))
+jest.mock("store/processors/processor.provider", () => ({ __esModule: true, default: () => null }))
+jest.mock("store/entities/entity.provider", () => ({ __esModule: true, default: () => null }))
+jest.mock("components/Header/ClearAllButton", () => ({ ClearAllButton: () => null }))
+jest.mock("components/Header/HeaderUserInfo", () => ({ HeaderUserInfo: () => null }))
+jest.mock("next/link", () => ({ __esModule: true, default: () => null }))
+
+// ─── Imports ─────────────────────────────────────────────────────────────────
+import * as DemoLayoutModule from "app/(demo)/layout"
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("(demo) layout route-segment config", () => {
+  // Regression guard for the demo image header bug: the Dockerfile builds with
+  // AUTHENTICATED unset, so the only dynamic API (auth()) is never invoked at
+  // build time and Next.js statically pre-renders the layout with the
+  // unauthenticated header baked in. At runtime AUTHENTICATED=true but the
+  // static route never re-runs, so the user/tenant/logout controls never show.
+  // `export const dynamic = "force-dynamic"` opts the segment out of static
+  // prerendering so auth() runs per request. Removing it reintroduces the bug.
+  it("forces dynamic rendering so auth() runs per request at runtime", () => {
+    expect((DemoLayoutModule as { dynamic?: string }).dynamic).toBe("force-dynamic")
+  })
+})

--- a/app/(demo)/layout.tsx
+++ b/app/(demo)/layout.tsx
@@ -8,6 +8,14 @@ import { auth } from "lib/auth"
 import EntityProvider from "store/entities/entity.provider"
 import ProcessorProvider from "store/processors/processor.provider"
 
+// Opt this segment out of static prerendering. The Dockerfile builds the image
+// with AUTHENTICATED unset, so at build time the only dynamic API (auth(),
+// guarded by `if (AUTHENTICATED)` below) is never invoked and Next.js would
+// otherwise statically pre-render the layout with the unauthenticated header
+// baked in. Forcing dynamic rendering ensures auth() runs per request against
+// the runtime AUTHENTICATED value, so the user/tenant/logout controls appear.
+export const dynamic = "force-dynamic"
+
 const AUTHENTICATED = process.env.AUTHENTICATED === "true"
 
 export default async function DemoLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## What

Add `export const dynamic = "force-dynamic"` to the `(demo)` layout so the segment is rendered per request instead of being statically pre-rendered at build time.

## Why

The demo image renders only the bare **Clear All** button (no username, tenant, or logout controls) even when `AUTHENTICATED=true` at runtime. Root cause:

- The `Dockerfile` builder stage runs `next build` with `AUTHENTICATED` unset.
- The only dynamic API in the `(demo)` layout is `auth()`, and it sits inside `if (AUTHENTICATED)`.
- With `AUTHENTICATED` false at build time, `auth()` is never invoked, so Next.js statically pre-renders the layout with the unauthenticated header branch baked in.
- At runtime `AUTHENTICATED=true`, but the static route never re-runs, so the authenticated header never appears.

`npm run dev` works because it never pre-renders, which is why the bug only showed up in the container image.

`force-dynamic` opts the segment out of static prerendering, so `auth()` runs per request against the runtime `AUTHENTICATED` value and the header gate evaluates against the live session.

## Changes

- `app/(demo)/layout.tsx` - add `export const dynamic = "force-dynamic"` with an explanatory comment.
- `__tests__/demo-layout.dynamic.test.ts` - new route-segment-config regression guard asserting the export is present (a Jest unit test cannot reproduce a `next build` prerender, so this guards against accidental removal of the fix).

## Testing

- New test fails without the fix (`Received: undefined`) and passes with it.
- Full suite green: 44 suites, 644 tests.

Fixes #139


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Demo layout now renders fresh content on each request instead of using prerendered and cached content.

* **Tests**
  * Added regression test for dynamic rendering configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->