### PR TITLE
fix(socket): pass secureCookie to getToken so HTTPS sessions authorise (#141)

### DIFF
--- a/__tests__/socket-auth.test.ts
+++ b/__tests__/socket-auth.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment node
+ */
+// SPDX-License-Identifier: Apache-2.0
+
+import { resolveUseSecureCookies } from "lib/socket-auth"
+
+// Regression guard for the AWS "no lights" bug (issue #141): over HTTPS,
+// Auth.js issues `__Secure-authjs.session-token`, but the Socket.IO auth
+// middleware's getToken() call defaulted secureCookie to false and looked for
+// the unprefixed `authjs.session-token`, so it never found the cookie, rejected
+// every socket as Unauthorized, and no rule/typology subscriptions were made.
+// The fix derives secureCookie from AUTH_URL; this helper encodes that decision.
+describe("resolveUseSecureCookies", () => {
+  it("returns true for an HTTPS AUTH_URL so the __Secure- session cookie is read", () => {
+    expect(resolveUseSecureCookies("https://demo.beta.tazama.org")).toBe(true)
+  })
+
+  it("returns false for an HTTP AUTH_URL (local dev uses the unprefixed cookie)", () => {
+    expect(resolveUseSecureCookies("http://localhost:3011")).toBe(false)
+  })
+
+  it("returns false for an empty AUTH_URL", () => {
+    expect(resolveUseSecureCookies("")).toBe(false)
+  })
+
+  it("returns false for an undefined AUTH_URL", () => {
+    expect(resolveUseSecureCookies(undefined)).toBe(false)
+  })
+})

--- a/lib/socket-auth.js
+++ b/lib/socket-auth.js
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Determines whether Auth.js secure cookies are in use for the current
+ * deployment, so the Socket.IO auth middleware in `server.js` can read the
+ * correctly-prefixed NextAuth session cookie when calling `getToken`.
+ *
+ * Auth.js issues the session cookie as `__Secure-authjs.session-token` when the
+ * app is served over HTTPS, and `authjs.session-token` (no prefix) over HTTP.
+ * `getToken` defaults `secureCookie` to `false`, so without this signal it only
+ * ever looks for the unprefixed cookie - and over HTTPS the cookie is never
+ * found, every socket handshake is rejected as Unauthorized, and no realtime
+ * subscriptions are created. Deriving the flag from AUTH_URL keeps the issuing
+ * side (Auth.js) and the verifying side (`getToken`) in agreement.
+ *
+ * Authored as CommonJS so `server.js` can `require()` it directly.
+ *
+ * @param {string | undefined} authUrl - the AUTH_URL / NEXTAUTH_URL value
+ * @returns {boolean} true when secure (HTTPS) cookies should be expected
+ */
+function resolveUseSecureCookies(authUrl) {
+  return (authUrl ?? "").startsWith("https://")
+}
+
+module.exports = { resolveUseSecureCookies }

--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ const healthState = require("./lib/healthState")
 const { fetchNetworkMapWithRetry } = require("./lib/network-map")
 const { deriveSubjectsFromNetworkMap } = require("./lib/network-map-subjects")
 const { RetryAbortedError } = require("./lib/retry")
+const { resolveUseSecureCookies } = require("./lib/socket-auth")
 
 // ---------------------------------------------------------------------------
 // Config
@@ -31,6 +32,12 @@ const TP_INTERDICTION_DESTINATION = process.env.TP_INTERDICTION_DESTINATION || "
 const ADMIN_SERVICE_URL = process.env.ADMIN_SERVICE_URL
 const NATS_SERVER_URL = process.env.NATS_SERVER_URL
 const NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET
+// Over HTTPS, Auth.js issues the session cookie as `__Secure-authjs.session-token`.
+// getToken() defaults secureCookie to false and would look for the unprefixed
+// `authjs.session-token`, never finding it and rejecting every socket. Derive the
+// flag from AUTH_URL so the verifying side matches the issuing side.
+const AUTH_URL = process.env.AUTH_URL ?? process.env.NEXTAUTH_URL ?? ""
+const USE_SECURE_COOKIES = resolveUseSecureCookies(AUTH_URL)
 
 // ---------------------------------------------------------------------------
 // Inline filter helpers (mirrors lib/nats-helpers.ts)
@@ -475,7 +482,7 @@ app.prepare().then(() => {
       // getToken reads the encrypted NextAuth session cookie from the request
       const { getToken } = await import("next-auth/jwt")
       const req = socket.request
-      const token = await getToken({ req, secret: NEXTAUTH_SECRET })
+      const token = await getToken({ req, secret: NEXTAUTH_SECRET, secureCookie: USE_SECURE_COOKIES })
       if (!token) {
         return next(new Error("Unauthorized"))
       }


### PR DESCRIPTION
## What

Fixes the Socket.IO auth middleware so authenticated clients connect over **HTTPS**, restoring the realtime rule/typology lights on the AWS beta deployment.

Closes #141.

## Why

Over HTTPS, Auth.js issues the session cookie as `__Secure-authjs.session-token`. The middleware called `getToken({ req, secret })` without `secureCookie`, and `@auth/core` defaults `secureCookie` to `false` - so `getToken` looked for the unprefixed `authjs.session-token` and used it as the decryption salt. The cookie was never found, every socket handshake was silently rejected as `Unauthorized`, the `connection` handler never ran, and no `ruleResponse` / `typoResponse` subscriptions were created. Result: no lights, blank typologies on AWS. Local dev worked only because it runs over HTTP with the unprefixed cookie.

## How

- New CommonJS helper `lib/socket-auth.js` exporting `resolveUseSecureCookies(authUrl)` (true when `authUrl` starts with `https://`).
- `server.js` derives `USE_SECURE_COOKIES` from `AUTH_URL` (falling back to `NEXTAUTH_URL`) and passes `secureCookie: USE_SECURE_COOKIES` to `getToken`, so the verifying side agrees with the issuing side on both the cookie name and the salt.

## Tests

- Added `__tests__/socket-auth.test.ts` (TDD red -> green) covering HTTPS -> `true`, HTTP -> `false`, empty -> `false`, undefined -> `false`.
- Full suite: 45 suites / 648 tests pass.

## Verification on AWS (post-merge)

After deploy, log in to the demo and confirm the container log shows `Client connected <id> tenantId: ...` and that rule/typology lights paint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Socket.IO authentication to correctly handle secure cookies based on connection protocol (HTTPS vs HTTP), improving session reliability.

* **Tests**
  * Added regression test coverage for authentication cookie protocol detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->