### PR TITLE
feat: targeted batch fetch of network-map configs (#143)

### DIFF
--- a/__tests__/bff-network-map-auth.test.ts
+++ b/__tests__/bff-network-map-auth.test.ts
@@ -50,7 +50,27 @@ beforeEach(() => {
 describe("GET /api/network-map - authenticated branch", () => {
   it("forwards the session JWT to all three admin-service calls", async () => {
     auth.mockResolvedValue({ accessToken: "test-jwt" })
-    adminGet.mockResolvedValue({ data: [] })
+    // A referencing map is required for the route to issue the rule/typology
+    // batch calls (an empty map yields no keys and those calls are skipped).
+    adminGet.mockImplementation((path: string) => {
+      if (path.includes("/network_map")) {
+        return Promise.resolve({
+          data: [
+            {
+              active: true,
+              messages: [
+                {
+                  typologies: [
+                    { id: "typology-processor@1.0.0", cfg: "999@1.0.0", rules: [{ id: "901@1.0.0", cfg: "1.0.0" }] },
+                  ],
+                },
+              ],
+            },
+          ],
+        })
+      }
+      return Promise.resolve({ data: [] })
+    })
 
     const response = await GET()
     expect(response.status).toBe(200)

--- a/__tests__/bff-network-map.test.ts
+++ b/__tests__/bff-network-map.test.ts
@@ -60,8 +60,12 @@ describe("GET /api/network-map", () => {
               {
                 typologies: [
                   {
+                    id: "typology-processor@1.0.0",
                     cfg: "999@1.0.0",
-                    rules: [{ id: "901@1.0.0" }, { id: "EFRuP@1.0.0" }],
+                    rules: [
+                      { id: "901@1.0.0", cfg: "1.0.0" },
+                      { id: "EFRuP@1.0.0", cfg: "none" },
+                    ],
                   },
                 ],
               },
@@ -74,7 +78,12 @@ describe("GET /api/network-map", () => {
       })
       .mockResolvedValueOnce({
         data: [
-          { cfg: "999@1.0.0", desc: "Typology 999", workflow: { interdictionThreshold: 100, alertThreshold: 50 } },
+          {
+            id: "typology-processor@1.0.0",
+            cfg: "999@1.0.0",
+            desc: "Typology 999",
+            workflow: { interdictionThreshold: 100, alertThreshold: 50 },
+          },
         ],
       })
 

--- a/__tests__/bff-network-map.test.ts
+++ b/__tests__/bff-network-map.test.ts
@@ -22,6 +22,28 @@ import { adminGet, TazamaClientError } from "lib/tazama-client"
 
 const mockAdminGet = adminGet as jest.Mock
 
+// A network map that references one rule and one typology, so the route's
+// batch-fetch actually issues the rule and typology calls (an empty/absent map
+// yields no keys and those calls are skipped).
+const REFERENCING_MAP = {
+  data: [
+    {
+      active: true,
+      messages: [
+        {
+          typologies: [
+            {
+              id: "typology-processor@1.0.0",
+              cfg: "999@1.0.0",
+              rules: [{ id: "901@1.0.0", cfg: "1.0.0" }],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
 beforeEach(() => {
   mockAdminGet.mockReset()
 })
@@ -75,8 +97,11 @@ describe("GET /api/network-map", () => {
     expect(body.typologiesEFRuP).toEqual([{ typology: "999", efrupResult: undefined }])
   })
 
-  it("calls all three admin endpoints in parallel with the JWT", async () => {
-    mockAdminGet.mockResolvedValue({ data: [] })
+  it("fetches network_map first, then batch-fetches rule and typology with the JWT", async () => {
+    mockAdminGet.mockImplementation((path: string) => {
+      if (path.includes("/network_map")) return Promise.resolve(REFERENCING_MAP)
+      return Promise.resolve({ data: [] })
+    })
 
     await GET()
 
@@ -115,10 +140,11 @@ describe("GET /api/network-map", () => {
   })
 
   it("returns 504 for a DOMException TimeoutError on the rule call and identifies the source", async () => {
-    mockAdminGet
-      .mockResolvedValueOnce({ data: [] })
-      .mockRejectedValueOnce(new DOMException("timed out", "TimeoutError"))
-      .mockResolvedValueOnce({ data: [] })
+    mockAdminGet.mockImplementation((path: string) => {
+      if (path.includes("/network_map")) return Promise.resolve(REFERENCING_MAP)
+      if (path.includes("/rule")) return Promise.reject(new DOMException("timed out", "TimeoutError"))
+      return Promise.resolve({ data: [] })
+    })
 
     const response = await GET()
     const body = await response.json()
@@ -130,10 +156,11 @@ describe("GET /api/network-map", () => {
   })
 
   it("returns 502 for an unexpected error on the typology call and identifies the source", async () => {
-    mockAdminGet
-      .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({ data: [] })
-      .mockRejectedValueOnce(new Error("connection refused"))
+    mockAdminGet.mockImplementation((path: string) => {
+      if (path.includes("/network_map")) return Promise.resolve(REFERENCING_MAP)
+      if (path.includes("/typology")) return Promise.reject(new Error("connection refused"))
+      return Promise.resolve({ data: [] })
+    })
 
     const response = await GET()
     const body = await response.json()
@@ -143,11 +170,13 @@ describe("GET /api/network-map", () => {
     expect(body.failures[0]).toMatchObject({ source: "typology", status: 502 })
   })
 
-  it("reports every failed source and uses the worst status when multiple calls fail", async () => {
-    mockAdminGet
-      .mockRejectedValueOnce(new TazamaClientError(503, "nm down"))
-      .mockRejectedValueOnce(new DOMException("timed out", "TimeoutError"))
-      .mockResolvedValueOnce({ data: [] })
+  it("reports every failed source and uses the worst status when both batch calls fail", async () => {
+    mockAdminGet.mockImplementation((path: string) => {
+      if (path.includes("/network_map")) return Promise.resolve(REFERENCING_MAP)
+      if (path.includes("/rule")) return Promise.reject(new TazamaClientError(503, "rule down"))
+      if (path.includes("/typology")) return Promise.reject(new DOMException("timed out", "TimeoutError"))
+      return Promise.resolve({ data: [] })
+    })
 
     const response = await GET()
     const body = await response.json()
@@ -155,7 +184,7 @@ describe("GET /api/network-map", () => {
     // 504 (timeout) > 503 (service unavailable) -> worst status wins.
     expect(response.status).toBe(504)
     expect(body.failures).toHaveLength(2)
-    expect(body.failures.map((f: { source: string }) => f.source).sort()).toEqual(["network_map", "rule"])
+    expect(body.failures.map((f: { source: string }) => f.source).sort()).toEqual(["rule", "typology"])
   })
 
   it("succeeds when admin-service calls succeed even if one of them returns an empty list", async () => {

--- a/__tests__/network-map-keys.test.ts
+++ b/__tests__/network-map-keys.test.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+import { collectConfigKeys } from "lib/network-map-keys"
+
+describe("collectConfigKeys", () => {
+  it("returns empty sets for a missing / empty network map", () => {
+    expect(collectConfigKeys(null)).toEqual({ ruleKeys: [], typologyKeys: [] })
+    expect(collectConfigKeys(undefined)).toEqual({ ruleKeys: [], typologyKeys: [] })
+    expect(collectConfigKeys({})).toEqual({ ruleKeys: [], typologyKeys: [] })
+    expect(collectConfigKeys({ messages: [] })).toEqual({ ruleKeys: [], typologyKeys: [] })
+  })
+
+  it("collects the (id, cfg) pair of every referenced typology and rule", () => {
+    // Real runtime shape: the typology's identifying value lives in `cfg`
+    // (e.g. "030@1.0.0") while `id` is the generic processor name. The helper
+    // must take both verbatim - they are exactly what admin-service stores as
+    // (typologyid, typologycfg) / (ruleid, rulecfg).
+    const networkMap = {
+      messages: [
+        {
+          typologies: [
+            {
+              id: "typology-processor@1.0.0",
+              cfg: "030@1.0.0",
+              rules: [
+                { id: "003@1.0.0", cfg: "1.0.0" },
+                { id: "028@1.0.0", cfg: "1.0.0" },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    const { ruleKeys, typologyKeys } = collectConfigKeys(networkMap)
+
+    expect(typologyKeys).toEqual([{ id: "typology-processor@1.0.0", cfg: "030@1.0.0" }])
+    expect(ruleKeys).toEqual([
+      { id: "003@1.0.0", cfg: "1.0.0" },
+      { id: "028@1.0.0", cfg: "1.0.0" },
+    ])
+  })
+
+  it("de-duplicates on the full (id, cfg) tuple across messages and typologies", () => {
+    // Typologies routinely share the generic processor `id` and differ only by
+    // `cfg`, so dedup MUST be on the full (id, cfg) tuple, not on `id` alone.
+    const networkMap = {
+      messages: [
+        {
+          typologies: [
+            { id: "typology-processor@1.0.0", cfg: "030@1.0.0", rules: [{ id: "003@1.0.0", cfg: "1.0.0" }] },
+          ],
+        },
+        {
+          typologies: [
+            // exact duplicate of the first typology + rule -> collapsed
+            { id: "typology-processor@1.0.0", cfg: "030@1.0.0", rules: [{ id: "003@1.0.0", cfg: "1.0.0" }] },
+            // same id, different cfg -> a distinct typology config, kept
+            { id: "typology-processor@1.0.0", cfg: "031@1.0.0", rules: [{ id: "003@1.0.0", cfg: "2.0.0" }] },
+          ],
+        },
+      ],
+    }
+
+    const { ruleKeys, typologyKeys } = collectConfigKeys(networkMap)
+
+    expect(ruleKeys).toEqual([
+      { id: "003@1.0.0", cfg: "1.0.0" },
+      { id: "003@1.0.0", cfg: "2.0.0" },
+    ])
+    expect(typologyKeys).toEqual([
+      { id: "typology-processor@1.0.0", cfg: "030@1.0.0" },
+      { id: "typology-processor@1.0.0", cfg: "031@1.0.0" },
+    ])
+  })
+
+  it("includes the EFRuP rule's (id, cfg) when the map references it", () => {
+    const networkMap = {
+      messages: [
+        {
+          typologies: [
+            {
+              id: "typology-processor@1.0.0",
+              cfg: "001@1.0.0",
+              rules: [
+                { id: "EFRuP@1.0.0", cfg: "none" },
+                { id: "006@1.0.0", cfg: "1.0.0" },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    const { ruleKeys } = collectConfigKeys(networkMap)
+
+    expect(ruleKeys).toContainEqual({ id: "EFRuP@1.0.0", cfg: "none" })
+  })
+
+  it("tolerates a typology with no rules array (collects the typology, no rules)", () => {
+    const networkMap = { messages: [{ typologies: [{ id: "typology-processor@1.0.0", cfg: "030@1.0.0" }] }] }
+
+    const { ruleKeys, typologyKeys } = collectConfigKeys(networkMap)
+
+    expect(typologyKeys).toEqual([{ id: "typology-processor@1.0.0", cfg: "030@1.0.0" }])
+    expect(ruleKeys).toEqual([])
+  })
+
+  it("walks every message in the map (not just the first)", () => {
+    const networkMap = {
+      messages: [
+        {
+          typologies: [
+            { id: "typology-processor@1.0.0", cfg: "030@1.0.0", rules: [{ id: "003@1.0.0", cfg: "1.0.0" }] },
+          ],
+        },
+        {
+          typologies: [
+            { id: "typology-processor@1.0.0", cfg: "028@1.0.0", rules: [{ id: "018@1.0.0", cfg: "1.0.0" }] },
+          ],
+        },
+      ],
+    }
+
+    const { ruleKeys, typologyKeys } = collectConfigKeys(networkMap)
+
+    expect(typologyKeys).toEqual([
+      { id: "typology-processor@1.0.0", cfg: "030@1.0.0" },
+      { id: "typology-processor@1.0.0", cfg: "028@1.0.0" },
+    ])
+    expect(ruleKeys).toEqual([
+      { id: "003@1.0.0", cfg: "1.0.0" },
+      { id: "018@1.0.0", cfg: "1.0.0" },
+    ])
+  })
+})

--- a/__tests__/network-map-keys.test.ts
+++ b/__tests__/network-map-keys.test.ts
@@ -132,4 +132,67 @@ describe("collectConfigKeys", () => {
       { id: "018@1.0.0", cfg: "1.0.0" },
     ])
   })
+
+  it("skips a typology ref missing id or cfg and warns, keeping well-formed siblings", () => {
+    // The network map is an external admin-service payload; a corrupt ref must
+    // never reach the wire as `keys[i][id]=undefined`. Drop it, warn, and let
+    // the rest of the map resolve.
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+    const networkMap = {
+      messages: [
+        {
+          typologies: [
+            // missing id
+            { cfg: "030@1.0.0", rules: [{ id: "003@1.0.0", cfg: "1.0.0" }] },
+            // empty cfg
+            { id: "typology-processor@1.0.0", cfg: "", rules: [{ id: "028@1.0.0", cfg: "1.0.0" }] },
+            // well-formed sibling, still collected
+            { id: "typology-processor@1.0.0", cfg: "031@1.0.0", rules: [{ id: "018@1.0.0", cfg: "1.0.0" }] },
+          ],
+        },
+      ],
+    } as unknown as Parameters<typeof collectConfigKeys>[0]
+
+    const { ruleKeys, typologyKeys } = collectConfigKeys(networkMap)
+
+    expect(typologyKeys).toEqual([{ id: "typology-processor@1.0.0", cfg: "031@1.0.0" }])
+    // rules under the dropped typologies are dropped with them
+    expect(ruleKeys).toEqual([{ id: "018@1.0.0", cfg: "1.0.0" }])
+    expect(warn).toHaveBeenCalledTimes(2)
+
+    warn.mockRestore()
+  })
+
+  it("skips a rule ref missing id or cfg and warns, keeping well-formed siblings", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+    const networkMap = {
+      messages: [
+        {
+          typologies: [
+            {
+              id: "typology-processor@1.0.0",
+              cfg: "030@1.0.0",
+              rules: [
+                { id: "003@1.0.0", cfg: "1.0.0" },
+                // missing cfg
+                { id: "028@1.0.0" },
+                // empty id
+                { id: "", cfg: "1.0.0" },
+              ],
+            },
+          ],
+        },
+      ],
+    } as unknown as Parameters<typeof collectConfigKeys>[0]
+
+    const { ruleKeys, typologyKeys } = collectConfigKeys(networkMap)
+
+    expect(typologyKeys).toEqual([{ id: "typology-processor@1.0.0", cfg: "030@1.0.0" }])
+    expect(ruleKeys).toEqual([{ id: "003@1.0.0", cfg: "1.0.0" }])
+    expect(warn).toHaveBeenCalledTimes(2)
+
+    warn.mockRestore()
+  })
 })

--- a/__tests__/network-map-route.test.ts
+++ b/__tests__/network-map-route.test.ts
@@ -1,0 +1,284 @@
+/**
+ * @jest-environment node
+ */
+// SPDX-License-Identifier: Apache-2.0
+
+// ─── Mocks (hoisted by Jest before imports) ──────────────────────────────────
+
+// next/server: stub NextResponse.json so the route can build a response without
+// the edge runtime. We assert on the admin-service calls, not the body, so a
+// lightweight `{ body, status }` capture is enough.
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body: unknown, init?: { status?: number }) => ({ body, status: init?.status ?? 200 })),
+  },
+}))
+
+// lib/auth: the real module imports next-auth and validates env at load time.
+// Most tests run with AUTHENTICATED=false so auth() is never called; the jwt
+// test flips AUTHENTICATED=true and drives this mock to supply a session.
+const auth = jest.fn()
+jest.mock("lib/auth", () => ({ auth: (...args: unknown[]) => auth(...args) }))
+
+// lib/tazama-client: capture every admin-service call so we can assert exactly
+// which configs are fetched and with what querystring.
+const adminGet = jest.fn()
+jest.mock("lib/tazama-client", () => ({
+  adminGet: (...args: unknown[]) => adminGet(...args),
+  TazamaClientError: class TazamaClientError extends Error {
+    constructor(
+      public readonly status: number,
+      message: string
+    ) {
+      super(message)
+      this.name = "TazamaClientError"
+    }
+  },
+}))
+
+// lib/network-map-transform: isolate the route from transform behaviour - this
+// suite only cares which admin-service calls the route makes and with what.
+const transformNetworkMap = jest.fn(() => ({ rules: [], typologies: [], typologiesEFRuP: [] }))
+jest.mock("lib/network-map-transform", () => ({
+  transformNetworkMap: (...args: unknown[]) => transformNetworkMap(...args),
+}))
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const RULE_PATH = "/v1/admin/configuration/rule"
+const TYPO_PATH = "/v1/admin/configuration/typology"
+const NM_PATH = "/v1/admin/configuration/network_map"
+
+function loadRoute(): { GET: () => Promise<{ body: unknown; status: number }> } {
+  let mod: { GET: () => Promise<{ body: unknown; status: number }> } | undefined
+  jest.isolateModules(() => {
+    mod = require("app/api/network-map/route") as { GET: () => Promise<{ body: unknown; status: number }> }
+  })
+  if (!mod) throw new Error("failed to load network-map route module")
+  return mod
+}
+
+function callPathsStartingWith(prefix: string): string[] {
+  return adminGet.mock.calls.map((c) => String(c[0])).filter((p) => p.startsWith(prefix))
+}
+
+function queryOf(path: string): URLSearchParams {
+  return new URLSearchParams(path.split("?")[1] ?? "")
+}
+
+const ORIGINAL_AUTHENTICATED = process.env.AUTHENTICATED
+
+beforeEach(() => {
+  process.env.AUTHENTICATED = "false"
+  adminGet.mockReset()
+  auth.mockReset()
+  transformNetworkMap.mockClear()
+})
+
+afterAll(() => {
+  if (ORIGINAL_AUTHENTICATED === undefined) delete process.env.AUTHENTICATED
+  else process.env.AUTHENTICATED = ORIGINAL_AUTHENTICATED
+})
+
+// A network map referencing two rules under one typology.
+const NETWORK_MAP = {
+  data: [
+    {
+      messages: [
+        {
+          typologies: [
+            {
+              id: "typology-processor@1.0.0",
+              cfg: "030@1.0.0",
+              rules: [
+                { id: "003@1.0.0", cfg: "1.0.0" },
+                { id: "028@1.0.0", cfg: "1.0.0" },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+function mockAdmin(networkMap: unknown): void {
+  adminGet.mockImplementation((path: string) => {
+    if (path.startsWith(NM_PATH)) return Promise.resolve(networkMap)
+    if (path.startsWith(RULE_PATH)) return Promise.resolve({ data: [] })
+    if (path.startsWith(TYPO_PATH)) return Promise.resolve({ data: [] })
+    return Promise.resolve(undefined)
+  })
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("GET /api/network-map - targeted batch fetch (#143)", () => {
+  it("still fetches the lone active network map via filters[active]=true", async () => {
+    mockAdmin(NETWORK_MAP)
+    const { GET } = loadRoute()
+
+    await GET()
+
+    const nmCalls = callPathsStartingWith(NM_PATH)
+    expect(nmCalls).toHaveLength(1)
+    expect(nmCalls[0]).toContain("filters[active]=true")
+    // network_map does NOT accept the keys set filter.
+    expect(nmCalls[0]).not.toContain("keys")
+  })
+
+  it("batch-fetches only the referenced rule (id, cfg) pairs with limit=all", async () => {
+    mockAdmin(NETWORK_MAP)
+    const { GET } = loadRoute()
+
+    await GET()
+
+    const ruleCalls = callPathsStartingWith(RULE_PATH)
+    expect(ruleCalls).toHaveLength(1)
+    const q = queryOf(ruleCalls[0])
+    expect(q.get("limit")).toBe("all")
+    expect(q.get("keys[0][id]")).toBe("003@1.0.0")
+    expect(q.get("keys[0][cfg]")).toBe("1.0.0")
+    expect(q.get("keys[1][id]")).toBe("028@1.0.0")
+    expect(q.get("keys[1][cfg]")).toBe("1.0.0")
+  })
+
+  it("batch-fetches only the referenced typology (id, cfg) pairs with limit=all", async () => {
+    mockAdmin(NETWORK_MAP)
+    const { GET } = loadRoute()
+
+    await GET()
+
+    const typoCalls = callPathsStartingWith(TYPO_PATH)
+    expect(typoCalls).toHaveLength(1)
+    const q = queryOf(typoCalls[0])
+    expect(q.get("limit")).toBe("all")
+    expect(q.get("keys[0][id]")).toBe("typology-processor@1.0.0")
+    expect(q.get("keys[0][cfg]")).toBe("030@1.0.0")
+  })
+
+  it("never fetches all rules/typologies - every rule/typology call carries a keys set", async () => {
+    mockAdmin(NETWORK_MAP)
+    const { GET } = loadRoute()
+
+    await GET()
+
+    const fetchAll = [...callPathsStartingWith(RULE_PATH), ...callPathsStartingWith(TYPO_PATH)].filter(
+      (p) => !p.includes("keys")
+    )
+    expect(fetchAll).toEqual([])
+  })
+
+  it("warns and skips the rule fetch when the active map references no rules", async () => {
+    const noRules = {
+      data: [{ messages: [{ typologies: [{ id: "typology-processor@1.0.0", cfg: "030@1.0.0", rules: [] }] }] }],
+    }
+    mockAdmin(noRules)
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined)
+    const { GET } = loadRoute()
+
+    await GET()
+
+    expect(warn).toHaveBeenCalled()
+    expect(callPathsStartingWith(RULE_PATH)).toEqual([])
+    // The transform must still receive an empty rule envelope (never `keys=[]`).
+    expect(transformNetworkMap).toHaveBeenCalledWith(noRules, { data: [] }, expect.anything())
+    warn.mockRestore()
+  })
+
+  it("warns and makes only the network_map call when the map references nothing", async () => {
+    const empty = { data: [{ messages: [] }] }
+    mockAdmin(empty)
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined)
+    const { GET } = loadRoute()
+
+    await GET()
+
+    expect(warn).toHaveBeenCalled()
+    expect(callPathsStartingWith(RULE_PATH)).toEqual([])
+    expect(callPathsStartingWith(TYPO_PATH)).toEqual([])
+    expect(callPathsStartingWith(NM_PATH)).toHaveLength(1)
+    expect(transformNetworkMap).toHaveBeenCalledWith(empty, { data: [] }, { data: [] })
+    warn.mockRestore()
+  })
+
+  // ─── Per-source failure contract ──────────────────────────────────────────
+  // The route fetches network_map FIRST (the keys derive from it), then
+  // batch-fetches rule + typology. Failures are reported per source and the
+  // response status is the max of the failing statuses (preserved from v3).
+
+  it("returns the network_map failure and skips rule/typology when the map fetch fails", async () => {
+    const { TazamaClientError } = require("lib/tazama-client") as {
+      TazamaClientError: new (s: number, m: string) => Error
+    }
+    adminGet.mockImplementation((path: string) => {
+      if (path.startsWith(NM_PATH)) return Promise.reject(new TazamaClientError(503, "network_map down"))
+      return Promise.resolve({ data: [] })
+    })
+    const { GET } = loadRoute()
+
+    const res = await GET()
+
+    expect(res.status).toBe(503)
+    const failures = (res.body as { failures: { source: string }[] }).failures
+    expect(failures.map((f) => f.source)).toContain("network_map")
+    // No keys can be derived from a failed map, so no rule/typology calls.
+    expect(callPathsStartingWith(RULE_PATH)).toEqual([])
+    expect(callPathsStartingWith(TYPO_PATH)).toEqual([])
+  })
+
+  it("reports a rule batch failure with its status while still fetching network_map and typology", async () => {
+    const { TazamaClientError } = require("lib/tazama-client") as {
+      TazamaClientError: new (s: number, m: string) => Error
+    }
+    adminGet.mockImplementation((path: string) => {
+      if (path.startsWith(NM_PATH)) return Promise.resolve(NETWORK_MAP)
+      if (path.startsWith(RULE_PATH)) return Promise.reject(new TazamaClientError(502, "rule down"))
+      if (path.startsWith(TYPO_PATH)) return Promise.resolve({ data: [] })
+      return Promise.resolve(undefined)
+    })
+    const { GET } = loadRoute()
+
+    const res = await GET()
+
+    expect(res.status).toBe(502)
+    const failures = (res.body as { failures: { source: string }[] }).failures
+    expect(failures.map((f) => f.source)).toContain("rule")
+    expect(callPathsStartingWith(NM_PATH)).toHaveLength(1)
+  })
+
+  it("returns the max status when both rule and typology batch fetches fail", async () => {
+    const { TazamaClientError } = require("lib/tazama-client") as {
+      TazamaClientError: new (s: number, m: string) => Error
+    }
+    adminGet.mockImplementation((path: string) => {
+      if (path.startsWith(NM_PATH)) return Promise.resolve(NETWORK_MAP)
+      if (path.startsWith(RULE_PATH)) return Promise.reject(new TazamaClientError(502, "rule down"))
+      if (path.startsWith(TYPO_PATH)) return Promise.reject(new TazamaClientError(504, "typology timed out"))
+      return Promise.resolve(undefined)
+    })
+    const { GET } = loadRoute()
+
+    const res = await GET()
+
+    expect(res.status).toBe(504)
+    const failures = (res.body as { failures: { source: string }[] }).failures
+    expect(failures.map((f) => f.source).sort()).toEqual(["rule", "typology"])
+  })
+
+  // ─── Authenticated path ───────────────────────────────────────────────────
+
+  it("forwards the session accessToken as the jwt to every admin-service call when AUTHENTICATED", async () => {
+    process.env.AUTHENTICATED = "true"
+    auth.mockResolvedValue({ accessToken: "jwt-123" })
+    mockAdmin(NETWORK_MAP)
+    const { GET } = loadRoute()
+
+    await GET()
+
+    expect(adminGet.mock.calls.length).toBeGreaterThanOrEqual(3)
+    for (const call of adminGet.mock.calls) {
+      expect(call[1]).toBe("jwt-123")
+    }
+  })
+})

--- a/__tests__/network-map-transform.test.ts
+++ b/__tests__/network-map-transform.test.ts
@@ -222,6 +222,38 @@ describe("transformNetworkMap", () => {
     expect(out.typologies[0].workflow).toEqual({ interdictionThreshold: null, alertThreshold: null })
   })
 
+  it("matches a typology doc by the full (id, cfg) tuple, not cfg alone", () => {
+    // A typology's `cfg` (e.g. "030@1.0.0") combines the typology number and a
+    // config version, but it is the (id, cfg) tuple that uniquely keys a
+    // typology config in admin-service. When two docs share a cfg, the doc whose
+    // `id` also matches the network-map reference must win.
+    const networkMap = {
+      data: [{ messages: [{ typologies: [{ id: "typology-processor@1.0.0", cfg: "030@1.0.0", rules: [] }] }] }],
+    }
+    const typologies = {
+      data: [
+        // Same cfg, different id - cfg-only matching would wrongly pick this first.
+        {
+          id: "other-processor@1.0.0",
+          cfg: "030@1.0.0",
+          desc: "WRONG",
+          workflow: { interdictionThreshold: 1, alertThreshold: 2 },
+        },
+        {
+          id: "typology-processor@1.0.0",
+          cfg: "030@1.0.0",
+          desc: "RIGHT",
+          workflow: { interdictionThreshold: 250, alertThreshold: 100 },
+        },
+      ],
+    }
+
+    const out = transformNetworkMap(networkMap, { data: [] }, typologies)
+
+    expect(out.typologies[0].typoDescription).toBe("RIGHT")
+    expect(out.typologies[0].workflow).toEqual({ interdictionThreshold: 250, alertThreshold: 100 })
+  })
+
   it("builds the rule-to-linked-typologies display map", () => {
     const networkMap = {
       data: [

--- a/app/api/network-map/route.ts
+++ b/app/api/network-map/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from "next/server"
 import type { Session } from "next-auth"
 import { auth } from "lib/auth"
+import { collectConfigKeys, type ConfigKey } from "lib/network-map-keys"
 import { transformNetworkMap } from "lib/network-map-transform"
 import { adminGet, TazamaClientError } from "lib/tazama-client"
 
@@ -34,6 +35,27 @@ function toFailure(source: Source, err: unknown): Failure {
   return { source, status: 502, message: `Failed to reach admin service for ${source}: ${message}` }
 }
 
+function failureResponse(failures: Failure[]) {
+  const status = Math.max(...failures.map((f) => f.status))
+  const sources = failures.map((f) => f.source).join(", ")
+  return NextResponse.json({ error: `admin-service call(s) failed: ${sources}`, failures }, { status })
+}
+
+// Build the admin-service `keys` set querystring: `limit=all` plus one
+// `keys[i][id]` / `keys[i][cfg]` pair per referenced config. URLSearchParams
+// percent-encodes the brackets, which the server's `qs` parser decodes back
+// into the nested array shape it expects.
+function buildKeysQuery(keys: ConfigKey[]): string {
+  const params = new URLSearchParams({ limit: "all" })
+  keys.forEach((k, i) => {
+    params.append(`keys[${i}][id]`, k.id)
+    params.append(`keys[${i}][cfg]`, k.cfg)
+  })
+  return params.toString()
+}
+
+const EMPTY_LIST = { data: [] as never[] }
+
 export async function GET() {
   let jwt: string | undefined
 
@@ -46,35 +68,59 @@ export async function GET() {
   }
 
   // The UI store consumer (`createUIFromNetworkMap`) expects a flat, hydrated
-  // shape `{ rules, typologies, typologiesEFRuP }`. v3 produced that shape in
-  // the BFF directly against Postgres; v4 must rebuild it from three
-  // admin-service calls. See issues #116, #120.
+  // shape `{ rules, typologies, typologiesEFRuP }`. v3 produced that in the BFF
+  // directly against Postgres; v4 rebuilds it from admin-service.
   //
-  // Use `allSettled` so that one failing admin call does not mask the others.
-  // Each failure is reported individually with its source endpoint.
-  const settled = await Promise.allSettled([
-    adminGet<NetworkMapResponse>("/v1/admin/configuration/network_map?filters[active]=true", jwt),
-    adminGet<RuleResponse>("/v1/admin/configuration/rule", jwt),
-    adminGet<TypologyResponse>("/v1/admin/configuration/typology", jwt),
+  // The active network map is self-describing - it lists the exact rule and
+  // typology (id, cfg) pairs it uses - so rather than fetching every config and
+  // culling the excess (#143), fetch the map first, then batch-fetch only the
+  // referenced configs via admin-service's `keys` set filter.
+
+  // 1. Active network map - the keys derive from it, so it must come first.
+  let networkMapResponse: NetworkMapResponse | undefined
+  try {
+    networkMapResponse = await adminGet<NetworkMapResponse>(
+      "/v1/admin/configuration/network_map?filters[active]=true",
+      jwt
+    )
+  } catch (err) {
+    return failureResponse([toFailure("network_map", err)])
+  }
+
+  // 2. Decompose the active map into the distinct (id, cfg) pairs it references.
+  const activeNetworkMap = (networkMapResponse?.data ?? [])[0]
+  const { ruleKeys, typologyKeys } = collectConfigKeys(activeNetworkMap as Parameters<typeof collectConfigKeys>[0])
+
+  // 3. Batch-fetch exactly those configs. An empty key set means the map
+  //    references none of that kind: skip the call (an empty `keys` set would
+  //    make admin-service fetch ALL configs) and hand the transform an empty
+  //    envelope instead.
+  if (ruleKeys.length === 0) {
+    console.warn("network-map: active map references no rules; skipping rule fetch")
+  }
+  if (typologyKeys.length === 0) {
+    console.warn("network-map: active map references no typologies; skipping typology fetch")
+  }
+
+  const [ruleSettled, typologySettled] = await Promise.allSettled([
+    ruleKeys.length > 0
+      ? adminGet<RuleResponse>(`/v1/admin/configuration/rule?${buildKeysQuery(ruleKeys)}`, jwt)
+      : Promise.resolve(EMPTY_LIST as RuleResponse),
+    typologyKeys.length > 0
+      ? adminGet<TypologyResponse>(`/v1/admin/configuration/typology?${buildKeysQuery(typologyKeys)}`, jwt)
+      : Promise.resolve(EMPTY_LIST as TypologyResponse),
   ])
 
   const failures: Failure[] = []
-  for (let i = 0; i < settled.length; i++) {
-    const result = settled[i]!
-    if (result.status === "rejected") {
-      failures.push(toFailure(SOURCES[i]!, result.reason))
-    }
-  }
+  if (ruleSettled.status === "rejected") failures.push(toFailure("rule", ruleSettled.reason))
+  if (typologySettled.status === "rejected") failures.push(toFailure("typology", typologySettled.reason))
 
   if (failures.length > 0) {
-    const status = Math.max(...failures.map((f) => f.status))
-    const sources = failures.map((f) => f.source).join(", ")
-    return NextResponse.json({ error: `admin-service call(s) failed: ${sources}`, failures }, { status })
+    return failureResponse(failures)
   }
 
-  const [networkMapResponse, ruleResponse, typologyResponse] = settled.map(
-    (r) => (r as PromiseFulfilledResult<unknown>).value
-  ) as [NetworkMapResponse, RuleResponse, TypologyResponse]
+  const ruleResponse = (ruleSettled as PromiseFulfilledResult<RuleResponse>).value
+  const typologyResponse = (typologySettled as PromiseFulfilledResult<TypologyResponse>).value
 
   try {
     const transformed = transformNetworkMap(networkMapResponse, ruleResponse, typologyResponse)

--- a/lib/network-map-keys.ts
+++ b/lib/network-map-keys.ts
@@ -24,13 +24,13 @@ export interface NetworkMapConfigKeys {
 }
 
 interface NetworkMapRuleRef {
-  id: string
-  cfg: string
+  id?: string
+  cfg?: string
 }
 
 interface NetworkMapTypologyRef {
-  id: string
-  cfg: string
+  id?: string
+  cfg?: string
   rules?: NetworkMapRuleRef[]
 }
 
@@ -53,8 +53,25 @@ export function collectConfigKeys(activeNetworkMap: NetworkMapConfig | null | un
   // config id/cfg, so it is a safe key delimiter.
   const tupleKey = (id: string, cfg: string): string => `${id}\u0000${cfg}`
 
+  // The active network map is an external admin-service payload, so a ref may
+  // be missing its id or cfg. Such a tuple would serialise to
+  // `keys[i][id]=undefined` and silently match nothing at admin-service, so
+  // drop it here and warn rather than letting it reach the wire.
+  const isWellFormed = <T extends NetworkMapRuleRef | NetworkMapTypologyRef>(
+    kind: string,
+    ref: T
+  ): ref is T & { id: string; cfg: string } => {
+    if (!ref.id || !ref.cfg) {
+      console.warn(`collectConfigKeys: skipping malformed ${kind} ref with missing id/cfg`, ref)
+      return false
+    }
+    return true
+  }
+
   for (const message of activeNetworkMap?.messages ?? []) {
     for (const typology of message.typologies ?? []) {
+      if (!isWellFormed("typology", typology)) continue
+
       const tKey = tupleKey(typology.id, typology.cfg)
       if (!typologySeen.has(tKey)) {
         typologySeen.add(tKey)
@@ -62,6 +79,8 @@ export function collectConfigKeys(activeNetworkMap: NetworkMapConfig | null | un
       }
 
       for (const rule of typology.rules ?? []) {
+        if (!isWellFormed("rule", rule)) continue
+
         const rKey = tupleKey(rule.id, rule.cfg)
         if (!ruleSeen.has(rKey)) {
           ruleSeen.add(rKey)

--- a/lib/network-map-keys.ts
+++ b/lib/network-map-keys.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Decomposes the active network map into the distinct (id, cfg) pairs it
+ * references, so the BFF can batch-fetch exactly those rule and typology
+ * configs from admin-service (the `keys` set filter) instead of fetching every
+ * config and culling the excess (#143).
+ *
+ * Pure and store-agnostic: it only knows the self-describing network-map shape
+ * (`messages[].typologies[]` and `messages[].typologies[].rules[]`, each a
+ * `{ id, cfg }` ref per `frms-coe-lib` `NetworkMap.ts`). De-duplication is on
+ * the full (id, cfg) tuple - two refs sharing an `id` but differing in `cfg`
+ * are distinct configs and both are kept.
+ */
+
+export interface ConfigKey {
+  id: string
+  cfg: string
+}
+
+export interface NetworkMapConfigKeys {
+  ruleKeys: ConfigKey[]
+  typologyKeys: ConfigKey[]
+}
+
+interface NetworkMapRuleRef {
+  id: string
+  cfg: string
+}
+
+interface NetworkMapTypologyRef {
+  id: string
+  cfg: string
+  rules?: NetworkMapRuleRef[]
+}
+
+interface NetworkMapMessage {
+  typologies?: NetworkMapTypologyRef[]
+}
+
+interface NetworkMapConfig {
+  messages?: NetworkMapMessage[]
+}
+
+export function collectConfigKeys(activeNetworkMap: NetworkMapConfig | null | undefined): NetworkMapConfigKeys {
+  const ruleKeys: ConfigKey[] = []
+  const typologyKeys: ConfigKey[] = []
+
+  const ruleSeen = new Set<string>()
+  const typologySeen = new Set<string>()
+
+  // De-dup on the full (id, cfg) tuple; a NUL separator can never appear in a
+  // config id/cfg, so it is a safe key delimiter.
+  const tupleKey = (id: string, cfg: string): string => `${id}\u0000${cfg}`
+
+  for (const message of activeNetworkMap?.messages ?? []) {
+    for (const typology of message.typologies ?? []) {
+      const tKey = tupleKey(typology.id, typology.cfg)
+      if (!typologySeen.has(tKey)) {
+        typologySeen.add(tKey)
+        typologyKeys.push({ id: typology.id, cfg: typology.cfg })
+      }
+
+      for (const rule of typology.rules ?? []) {
+        const rKey = tupleKey(rule.id, rule.cfg)
+        if (!ruleSeen.has(rKey)) {
+          ruleSeen.add(rKey)
+          ruleKeys.push({ id: rule.id, cfg: rule.cfg })
+        }
+      }
+    }
+  }
+
+  return { ruleKeys, typologyKeys }
+}

--- a/lib/network-map-transform.ts
+++ b/lib/network-map-transform.ts
@@ -22,9 +22,14 @@ import type { Rule, RuleBand, TypoEFRuP, Typology } from "store/processors/proce
 
 interface NetworkMapRuleRef {
   id: string | number
+  cfg?: string
 }
 
 interface NetworkMapTypology {
+  // The network map references a typology config by its full (id, cfg) tuple.
+  // `id` is the (generic) processor identifier and `cfg` (e.g. "030@1.0.0")
+  // combines the typology number and its config version.
+  id?: string
   cfg: string
   rules?: NetworkMapRuleRef[]
 }
@@ -64,6 +69,7 @@ interface RuleConfigDoc {
 }
 
 interface TypologyConfigDoc {
+  id?: string
   cfg?: string
   desc?: string
   workflow?: {
@@ -111,6 +117,20 @@ export function transformNetworkMap(
           typoDescription: "",
           workflow: { interdictionThreshold: null, alertThreshold: null },
           linkedRules: [],
+        }
+
+        // Hydrate description / workflow by the full (id, cfg) tuple. The network
+        // map references the typology config by both, so a cfg-only match would
+        // pick the wrong doc when two configs share a cfg. When the ref carries
+        // no `id` (legacy maps), the cfg comparison alone still resolves it.
+        const typoDoc = typologyDocs.find(
+          (t) => t.cfg === typology.cfg && (typology.id === undefined || t.id === typology.id)
+        )
+        if (typoDoc) {
+          newTypology.typoDescription = typoDoc.desc ?? ""
+          const wf = typoDoc.workflow ?? {}
+          newTypology.workflow.interdictionThreshold = wf.interdictionThreshold ?? null
+          newTypology.workflow.alertThreshold = wf.alertThreshold ?? null
         }
 
         if (typology.rules) {
@@ -216,15 +236,7 @@ export function transformNetworkMap(
   }
 
   // Hydrate typologies with description and workflow thresholds.
-  for (const typology of typologiesRes) {
-    const typoDoc = typologyDocs.find((t) => t.cfg === (typology.id as unknown as string))
-    if (!typoDoc) continue
-
-    typology.typoDescription = typoDoc.desc ?? ""
-    const wf = typoDoc.workflow ?? {}
-    typology.workflow.interdictionThreshold = wf.interdictionThreshold ?? null
-    typology.workflow.alertThreshold = wf.alertThreshold ?? null
-  }
+  // (Done inline in the walk above, by the full (id, cfg) tuple.)
 
   // Sort alphabetically by title.
   finalRules.sort((a, b) => a.title.localeCompare(b.title))


### PR DESCRIPTION
## What

STEP 2 (client side) of the Issue C split for #143: replace the BFF "fetch every rule/typology config and cull the excess" approach in the network-map route with a targeted batch fetch that uses admin-service's new `keys` set filter (merged server side in admin-service #427).

The active network map is self-describing - it lists the exact `(id, cfg)` rule and typology pairs it uses - so the route now fetches only those configs instead of the entire catalogue.

## Changes

**`lib/network-map-keys.ts`** (new)
- `collectConfigKeys(activeNetworkMap)` - a pure, store-agnostic helper that walks `messages[].typologies[]` and `messages[].typologies[].rules[]` and returns the distinct `{ id, cfg }` rule and typology keys, de-duplicated on the **full `(id, cfg)` tuple** (two refs sharing an `id` but differing in `cfg` are distinct configs and both are kept).

**`app/api/network-map/route.ts`**
- Fetches the active `network_map` **first** (the keys derive from it).
- Decomposes it via `collectConfigKeys`, then batch-fetches rule + typology by `keys[i][id]` / `keys[i][cfg]` with `limit=all`.
- When a key set is empty, logs a warning and **skips** that call (an empty `keys` set would make admin-service fetch all configs), handing the transform an empty envelope instead.
- Preserves the per-source failure reporting and worst-status (`Math.max`) response. A `network_map` failure short-circuits (no keys can be derived).

**`lib/network-map-transform.ts`**
- Typology docs are now matched by the **full `(id, cfg)` tuple** rather than `cfg` alone, fixing a latent bug where two configs sharing a `cfg` could resolve to the wrong doc. Legacy maps with no typology `id` still resolve by `cfg`.
- Widened `NetworkMapTypology` (adds `id`), `NetworkMapRuleRef` (adds `cfg`), and `TypologyConfigDoc` (adds `id`).

## Testing

- `__tests__/network-map-keys.test.ts` (new) - tuple collection, de-dup on the full tuple, EFRuP inclusion, missing-rules tolerance, multi-message walk, empty/missing map.
- `__tests__/network-map-route.test.ts` (new) - network_map fetched with `filters[active]=true` and no keys; rule/typology batch-fetched with keys + `limit=all`; never fetches all; warn + skip on empty sets; per-source failure contract; jwt forwarding.
- `__tests__/network-map-transform.test.ts` - added tuple-correct hydration spec.
- `__tests__/bff-network-map*.test.ts` - adapted to the batch-fetch sequence.
- Full suite: 665 passed. Lint (warnings only, pre-existing) and `next build` both pass.

Closes #143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Optimized the network map endpoint to fetch only actively referenced rule and typology configurations instead of all records, improving API efficiency.
  * Enhanced error handling to report per-source failure details with accurate HTTP status codes.

* **Bug Fixes**
  * Fixed typology resolution to correctly match configurations using both ID and configuration values, preventing mismatches when multiple typologies share the same configuration.

* **Tests**
  * Comprehensive test coverage for network map retrieval, batch fetching behavior, key extraction, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->