### PR TITLE
fix: stop new-Debtor condition GETs flooding the console with 404s

### DIFF
--- a/__tests__/bff-conditions-account.test.ts
+++ b/__tests__/bff-conditions-account.test.ts
@@ -89,13 +89,22 @@ describe("GET /api/conditions/account", () => {
     expect(response.status).toBe(400)
   })
 
-  it("mirrors TazamaClientError status", async () => {
+  it("maps upstream 404 to 204 (account not yet in admin DB = no conditions yet)", async () => {
     mockAdminGet.mockRejectedValueOnce(new TazamaClientError(404, "Account not found"))
 
     const req = getRequest({ id: "acct-001", schmenm: "MSISDN", agt: "bank-001" })
     const response = await GET(req)
 
-    expect(response.status).toBe(404)
+    expect(response.status).toBe(204)
+  })
+
+  it("mirrors non-404 TazamaClientError status", async () => {
+    mockAdminGet.mockRejectedValueOnce(new TazamaClientError(503, "Service unavailable"))
+
+    const req = getRequest({ id: "acct-001", schmenm: "MSISDN", agt: "bank-001" })
+    const response = await GET(req)
+
+    expect(response.status).toBe(503)
   })
 
   it("returns 504 on TimeoutError", async () => {

--- a/__tests__/bff-conditions-entity.test.ts
+++ b/__tests__/bff-conditions-entity.test.ts
@@ -83,13 +83,22 @@ describe("GET /api/conditions/entity", () => {
     expect(response.status).toBe(400)
   })
 
-  it("mirrors TazamaClientError status", async () => {
+  it("maps upstream 404 to 204 (entity not yet in admin DB = no conditions yet)", async () => {
     mockAdminGet.mockRejectedValueOnce(new TazamaClientError(404, "Entity not found"))
 
     const req = getRequest({ id: "entity-001", schmenm: "MSISDN" })
     const response = await GET(req)
 
-    expect(response.status).toBe(404)
+    expect(response.status).toBe(204)
+  })
+
+  it("mirrors non-404 TazamaClientError status", async () => {
+    mockAdminGet.mockRejectedValueOnce(new TazamaClientError(503, "Service unavailable"))
+
+    const req = getRequest({ id: "entity-001", schmenm: "MSISDN" })
+    const response = await GET(req)
+
+    expect(response.status).toBe(503)
   })
 
   it("returns 504 on TimeoutError", async () => {

--- a/app/api/conditions/account/route.ts
+++ b/app/api/conditions/account/route.ts
@@ -45,6 +45,13 @@ export async function GET(request: NextRequest) {
     }
     return NextResponse.json(data)
   } catch (err) {
+    // A brand-new account that has not yet been submitted to the admin service
+    // returns 404 ("Entity does not exist in the database"). For the demo this
+    // is a normal empty state ("no conditions yet"), not an error, so surface it
+    // as 204 rather than letting the browser log a 404. See tazama-demo#158.
+    if (err instanceof TazamaClientError && err.status === 404) {
+      return new NextResponse(null, { status: 204 })
+    }
     return errorResponse(err)
   }
 }

--- a/app/api/conditions/entity/route.ts
+++ b/app/api/conditions/entity/route.ts
@@ -44,6 +44,13 @@ export async function GET(request: NextRequest) {
     }
     return NextResponse.json(data)
   } catch (err) {
+    // A brand-new entity that has not yet been submitted to the admin service
+    // returns 404 ("Entity does not exist in the database"). For the demo this
+    // is a normal empty state ("no conditions yet"), not an error, so surface it
+    // as 204 rather than letting the browser log a 404. See tazama-demo#158.
+    if (err instanceof TazamaClientError && err.status === 404) {
+      return new NextResponse(null, { status: 204 })
+    }
     return errorResponse(err)
   }
 }

--- a/store/processors/processor.provider.tsx
+++ b/store/processors/processor.provider.tsx
@@ -757,6 +757,7 @@ const ProcessorProvider = ({ children }: Props) => {
 
   const handleEntityAccountConditions = async (resData: any) => {
     let filteredResData: ListCondition[] = []
+    if (!resData?.conditions) return filteredResData
     resData.conditions.map((item: any) => {
       let perspective: string = ""
       if (item.prsptvs.length === 1) {
@@ -792,6 +793,7 @@ const ProcessorProvider = ({ children }: Props) => {
   }
   const handleEntityConditions = async (resData: any) => {
     let filteredResData: ListCondition[] = []
+    if (!resData?.conditions) return filteredResData
     resData.conditions.map((item: any) => {
       let perspective: string = ""
       if (item.prsptvs.length === 1) {
@@ -1000,7 +1002,7 @@ const ProcessorProvider = ({ children }: Props) => {
 
     await entityResponses.map(async (response) => {
       if (response !== null) {
-        if (response.statusText !== "No Content") {
+        if (response.status !== 204) {
           const nttyConditions: ListCondition[] = await handleEntityConditions(response.data)
           nttyConditions.map((item) => {
             finalResponse.push(item)
@@ -1013,7 +1015,7 @@ const ProcessorProvider = ({ children }: Props) => {
       .filter((el) => el !== null)
       .map(async (response) => {
         if (response !== null) {
-          if (response.statusText !== "No Content") {
+          if (response.status !== 204) {
             const accountConditions: ListCondition[] = await handleEntityAccountConditions(response.data)
             accountConditions.map((item) => {
               finalResponse.push(item)
@@ -1094,7 +1096,7 @@ const ProcessorProvider = ({ children }: Props) => {
 
     await entityResponses.map(async (response) => {
       if (response !== null) {
-        if (response.statusText !== "No Content") {
+        if (response.status !== 204) {
           const nttyConditions: ListCondition[] = await handleEntityConditions(response.data)
           nttyConditions.map((item) => {
             finalResponse.push(item)
@@ -1107,7 +1109,7 @@ const ProcessorProvider = ({ children }: Props) => {
       .filter((el) => el !== null)
       .map(async (response) => {
         if (response !== null && response !== undefined) {
-          if (response.statusText !== "No Content") {
+          if (response.status !== 204) {
             const accountConditions: ListCondition[] = await handleEntityAccountConditions(response.data)
             accountConditions.map((item) => {
               finalResponse.push(item)


### PR DESCRIPTION
## Problem

Creating a new Debtor in the demo floods the browser console with `404` errors from the condition GET calls:

```
XHR GET /api/conditions/entity?id=<id>&schmenm=TAZAMA_EID    [HTTP/2 404]
XHR GET /api/conditions/account?id=<id>&schmenm=MSISDN&agt=fsp001   [HTTP/2 404]
```

A Debtor created in the demo is a **UI-only construct** - it has never been submitted, so the admin service graph has no node for it. The admin service hits its first guard and returns `404` ("Entity does not exist in the database"), and the BFF propagated that `404` straight to the browser. A `404` XHR is logged by the browser as a network error regardless of the app catching it in JS - that is the flood.

For a freshly created Debtor, **both `404` (entity not in DB) and `204` (entity in DB, no conditions) mean the same thing to the demo: "nothing to show yet."** The `404` is not an error state.

### Secondary factor (HTTP/2)

The client's empty-state guard used `response.statusText !== "No Content"`. HTTP/2 has no reason phrase, so `statusText` is always empty over HTTP/2 (as on the AWS demo) and the guard never matched - a `204`/empty body slipped through to `handleEntityConditions`, whose `resData.conditions.map(...)` then threw `conditions is undefined`.

## Changes

1. **BFF** (`app/api/conditions/entity/route.ts` + `app/api/conditions/account/route.ts`, `GET`): map an upstream `TazamaClientError` with `status === 404` to a `204`, so a not-yet-submitted entity/account surfaces a clean empty state instead of a browser-logged `404`. Non-404 statuses still pass through unchanged.
2. **Client** (`store/processors/processor.provider.tsx`): `getAllDebtorConditions` / `getAllCreditorConditions` now gate on `response.status !== 204` instead of the HTTP/2-broken `statusText !== "No Content"`.
3. **Mappers** (`handleEntityConditions` / `handleEntityAccountConditions`): early-return `[]` when `resData.conditions` is absent, so an empty body can never throw `conditions is undefined`.
4. **Tests** (`__tests__/bff-conditions-{entity,account}.test.ts`): the old "mirrors 404" case now asserts `204`, plus a new "mirrors non-404 status" case (503) retains passthrough coverage.

## Verification

- `npm run lint` - clean (pre-existing warnings only)
- `npm test` - 48 suites / 675 tests pass

## Acceptance criteria

- Creating a new Debtor no longer logs `404` errors for `/api/conditions/entity` or `/api/conditions/account`.
- The conditions panel shows an empty state (no crash) for an entity not yet in the admin database.
- Existing behaviour for entities that DO have conditions is unchanged.
