### PR TITLE
fix: bump axios to ^1.18.1 for CVE remediation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@t3-oss/env-nextjs": "^0.10.1",
         "@tazama-lf/auth-lib": "4.0.0-rc.5",
         "@tazama-lf/frms-coe-lib": "8.2.0-rc.6",
-        "axios": "^1.7.3",
+        "axios": "^1.18.1",
         "class-variance-authority": "^0.7.0",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -7786,9 +7786,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@radix-ui/react-tooltip": "^1.0.7",
     "@t3-oss/env-nextjs": "^0.10.1",
     "@tazama-lf/frms-coe-lib": "8.2.0-rc.6",
-    "axios": "^1.7.3",
+    "axios": "^1.18.1",
     "class-variance-authority": "^0.7.0",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",


### PR DESCRIPTION
# fix: bump axios to ^1.18.1 for CVE remediation

## Why

Part of the platform-wide axios remediation for the June 2026 advisory batch (CVE-2026-44486..44496 plus the June GHSA wave). `tazama-demo` declared a direct `axios ^1.7.3`, which resolved to a vulnerable version.

## What

- `package.json`: `axios ^1.7.3` -> `^1.18.1`
- `package-lock.json` regenerated; `npm ls axios` confirms `axios@1.18.1`

## Verification

- `npm run build` (next build) - clean
- `npm test` - 675/675 pass (48 suites)
- `npm run lint` (next lint) - no errors (pre-existing unused-var / sort-imports warnings only)

## Regression watch (axios 1.18.x behaviour changes)

- Cross-origin redirects now strip caller-set auth/API-key headers
- Malformed `http:`/`https:` URLs (missing `//`) now throw `ERR_INVALID_URL`
- Merged config/header objects are null-prototype
- `AxiosError.toJSON()` now redacts sensitive keys (log output changes)
